### PR TITLE
chore: remove docs/superpowers from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ dist/*
 !dist/tabdeck-card.js
 *.log
 .DS_Store
-
-# Internal planning docs — never publish
-docs/superpowers/


### PR DESCRIPTION
Removes the docs/superpowers/ reference from .gitignore so the path is no longer mentioned anywhere in the repo. Internal planning docs are now excluded locally via .git/info/exclude (not published).