### PR TITLE
Native HA card editor (hui-card-element-editor) with drill-in

### DIFF
--- a/dist/tabdeck-card.js
+++ b/dist/tabdeck-card.js
@@ -1252,9 +1252,15 @@ var __decorateClass = (decorators, target, key, kind) => {
   if (kind && result) __defProp(target, key, result);
   return result;
 };
+function pickCardEditorTag(has) {
+  if (has("hui-card-element-editor")) return "hui-card-element-editor";
+  if (has("ha-yaml-editor")) return "ha-yaml-editor";
+  return "textarea-json";
+}
 let TabdeckCardEditor = class extends i {
   constructor() {
     super(...arguments);
+    this._editingTab = null;
     this._cardError = null;
   }
   setConfig(config) {
@@ -1308,8 +1314,85 @@ let TabdeckCardEditor = class extends i {
     [tabs[index], tabs[target]] = [tabs[target], tabs[index]];
     this._emit({ ...this._config, tabs });
   }
+  _openCard(index) {
+    this._cardError = null;
+    this._editingTab = index;
+  }
+  _closeCard() {
+    this._editingTab = null;
+  }
+  get _lovelace() {
+    return this.lovelace ?? { config: { views: [] }, editMode: true };
+  }
+  _onNativeCardChanged(index, e2) {
+    var _a2;
+    e2.stopPropagation();
+    const config = (_a2 = e2.detail) == null ? void 0 : _a2.config;
+    if (!config) return;
+    this._patchTab(index, { card: config });
+  }
+  _onYamlCardChanged(index, e2) {
+    e2.stopPropagation();
+    const detail = e2.detail;
+    if ((detail == null ? void 0 : detail.isValid) === false) return;
+    if ((detail == null ? void 0 : detail.value) === void 0) return;
+    this._patchTab(index, { card: detail.value });
+  }
   render() {
     if (!this._config) return b``;
+    if (this._editingTab !== null) return this._renderCardView(this._editingTab);
+    return this._renderListView();
+  }
+  _renderCardView(index) {
+    const tab = this._config.tabs[index];
+    if (!tab) {
+      this._editingTab = null;
+      return this._renderListView();
+    }
+    const tag = pickCardEditorTag((t2) => !!customElements.get(t2));
+    return b`
+      <div class="card-editor-view">
+        <div class="card-editor-header">
+          <button class="back-to-list" @click=${this._closeCard}>← Back</button>
+          <span class="card-editor-title">${tab.name || `Tab ${index + 1}`}</span>
+        </div>
+        ${this._renderCardEditor(index, tab, tag)}
+      </div>
+    `;
+  }
+  _renderCardEditor(index, tab, tag) {
+    if (tag === "hui-card-element-editor") {
+      return b`
+        <hui-card-element-editor
+          .hass=${this.hass}
+          .lovelace=${this._lovelace}
+          .value=${tab.card ?? {}}
+          @config-changed=${(e2) => this._onNativeCardChanged(index, e2)}
+        ></hui-card-element-editor>
+      `;
+    }
+    if (tag === "ha-yaml-editor") {
+      return b`
+        <ha-yaml-editor
+          .defaultValue=${tab.card ?? {}}
+          @value-changed=${(e2) => this._onYamlCardChanged(index, e2)}
+        ></ha-yaml-editor>
+      `;
+    }
+    return b`
+      <label class="card-label"
+        >Card (JSON)
+        <textarea
+          class="tab-card-json"
+          rows="10"
+          .value=${JSON.stringify(tab.card ?? {}, null, 2)}
+          @change=${(e2) => this._editCardJson(index, e2.target.value)}
+        ></textarea>
+      </label>
+      ${this._cardError === index ? b`<div class="tab-card-error">Invalid JSON — not saved.</div>` : A}
+    `;
+  }
+  _renderListView() {
     const cfg = this._config;
     return b`
       <div class="editor">
@@ -1389,7 +1472,9 @@ let TabdeckCardEditor = class extends i {
 
         <div class="tabs">
           ${cfg.tabs.map(
-      (tab, index) => b`
+      (tab, index) => {
+        var _a2;
+        return b`
               <div class="tab">
                 <div class="tab-row">
                   <input
@@ -1426,18 +1511,14 @@ let TabdeckCardEditor = class extends i {
                     @input=${(e2) => this._patchTab(index, { badge: e2.target.value || void 0 })}
                   />
                 </div>
-                <label class="card-label"
-                  >Card (JSON)
-                  <textarea
-                    class="tab-card-json"
-                    rows="6"
-                    .value=${JSON.stringify(tab.card ?? {}, null, 2)}
-                    @change=${(e2) => this._editCardJson(index, e2.target.value)}
-                  ></textarea>
-                </label>
-                ${this._cardError === index ? b`<div class="tab-card-error">Invalid JSON — not saved.</div>` : ""}
+                <button class="edit-card" @click=${() => this._openCard(index)}>
+                  <span class="edit-card-label">Edit card</span>
+                  <span class="edit-card-type">${((_a2 = tab.card) == null ? void 0 : _a2.type) ?? "—"}</span>
+                  <span class="edit-card-arrow">→</span>
+                </button>
               </div>
-            `
+            `;
+      }
     )}
           <button class="add-tab" @click=${this._addTab}>+ Add tab</button>
         </div>
@@ -1486,6 +1567,44 @@ TabdeckCardEditor.styles = i$3`
     .tab-badge {
       flex: 1;
     }
+    .edit-card {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 8px 12px;
+      background: var(--secondary-background-color, #f5f5f5);
+      border: 1px solid var(--divider-color, #e0e0e0);
+      border-radius: 6px;
+      font-size: 13px;
+      text-align: left;
+    }
+    .edit-card-type {
+      color: var(--secondary-text-color);
+      font-family: var(--code-font-family, monospace);
+      font-size: 12px;
+    }
+    .edit-card-arrow {
+      margin-left: auto;
+      color: var(--secondary-text-color);
+    }
+    .card-editor-view {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .card-editor-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .card-editor-title {
+      font-weight: 500;
+    }
+    .back-to-list {
+      cursor: pointer;
+    }
     .card-label {
       font-size: 12px;
       gap: 4px;
@@ -1509,6 +1628,9 @@ __decorateClass([
 ], TabdeckCardEditor.prototype, "_config", 2);
 __decorateClass([
   r$1()
+], TabdeckCardEditor.prototype, "_editingTab", 2);
+__decorateClass([
+  r$1()
 ], TabdeckCardEditor.prototype, "_cardError", 2);
 TabdeckCardEditor = __decorateClass([
   t$1("tabdeck-card-editor")
@@ -1517,7 +1639,8 @@ const tabdeckCardEditor = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.d
   __proto__: null,
   get TabdeckCardEditor() {
     return TabdeckCardEditor;
-  }
+  },
+  pickCardEditorTag
 }, Symbol.toStringTag, { value: "Module" }));
 export {
   TabdeckCard

--- a/src/editor/tabdeck-card-editor.fallback.test.ts
+++ b/src/editor/tabdeck-card-editor.fallback.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import "./tabdeck-card-editor";
+
+// In this file NEITHER hui-card-element-editor NOR ha-yaml-editor is registered,
+// so the editor must fall back to the raw JSON textarea for nested card editing.
+
+async function mount(config: any) {
+  const el = document.createElement("tabdeck-card-editor") as any;
+  el.hass = { states: {} };
+  el.setConfig(config);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("tabdeck-card-editor JSON fallback", () => {
+  it("edits a tab's card via the JSON editor when valid", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    const handler = vi.fn();
+    el.addEventListener("config-changed", handler);
+    const ta = el.shadowRoot.querySelector(".tab-card-json");
+    expect(ta).toBeTruthy();
+    ta.value = '{"type":"light","entity":"light.kitchen"}';
+    ta.dispatchEvent(new Event("change"));
+    expect(handler).toHaveBeenCalled();
+    expect(handler.mock.calls.at(-1)[0].detail.config.tabs[0].card).toEqual({
+      type: "light",
+      entity: "light.kitchen",
+    });
+  });
+
+  it("does not emit when the card JSON is invalid", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    const handler = vi.fn();
+    el.addEventListener("config-changed", handler);
+    const ta = el.shadowRoot.querySelector(".tab-card-json");
+    ta.value = "{ not valid json";
+    ta.dispatchEvent(new Event("change"));
+    await el.updateComplete;
+    expect(handler).not.toHaveBeenCalled();
+    expect(el.shadowRoot.querySelector(".tab-card-error")).toBeTruthy();
+  });
+});

--- a/src/editor/tabdeck-card-editor.test.ts
+++ b/src/editor/tabdeck-card-editor.test.ts
@@ -1,5 +1,33 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
 import "./tabdeck-card-editor";
+import { pickCardEditorTag } from "./tabdeck-card-editor";
+
+// In this file the native HA editor element IS available, so the editor should
+// prefer hui-card-element-editor for nested card editing.
+beforeAll(() => {
+  if (!customElements.get("hui-card-element-editor")) {
+    customElements.define(
+      "hui-card-element-editor",
+      class extends HTMLElement {
+        _value: any;
+        _hass: any;
+        _lovelace: any;
+        set value(v: any) {
+          this._value = v;
+        }
+        get value() {
+          return this._value;
+        }
+        set hass(h: any) {
+          this._hass = h;
+        }
+        set lovelace(l: any) {
+          this._lovelace = l;
+        }
+      },
+    );
+  }
+});
 
 async function mount(config: any) {
   const el = document.createElement("tabdeck-card-editor") as any;
@@ -9,6 +37,22 @@ async function mount(config: any) {
   await el.updateComplete;
   return el;
 }
+
+describe("pickCardEditorTag", () => {
+  it("prefers hui-card-element-editor when available", () => {
+    expect(pickCardEditorTag((t) => t === "hui-card-element-editor")).toBe(
+      "hui-card-element-editor",
+    );
+  });
+
+  it("falls back to ha-yaml-editor when the native editor is missing", () => {
+    expect(pickCardEditorTag((t) => t === "ha-yaml-editor")).toBe("ha-yaml-editor");
+  });
+
+  it("falls back to a JSON textarea when neither element exists", () => {
+    expect(pickCardEditorTag(() => false)).toBe("textarea-json");
+  });
+});
 
 describe("tabdeck-card-editor", () => {
   it("renders one block per tab", async () => {
@@ -58,30 +102,58 @@ describe("tabdeck-card-editor", () => {
     expect(handler.mock.calls.at(-1)[0].detail.config.tabs[0].badge).toBe("sensor.unread");
   });
 
-  it("edits a tab's card via the JSON editor when valid", async () => {
-    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
-    const handler = vi.fn();
-    el.addEventListener("config-changed", handler);
-    const ta = el.shadowRoot.querySelector(".tab-card-json");
-    ta.value = '{"type":"light","entity":"light.kitchen"}';
-    ta.dispatchEvent(new Event("change"));
-    expect(handler).toHaveBeenCalled();
-    expect(handler.mock.calls.at(-1)[0].detail.config.tabs[0].card).toEqual({
-      type: "light",
-      entity: "light.kitchen",
+  it("shows an 'Edit card' button per tab and no raw JSON textarea in list view", async () => {
+    const el = await mount({
+      tabs: [{ name: "A", card: { type: "markdown" } }, { name: "B", card: { type: "light" } }],
     });
+    expect(el.shadowRoot.querySelectorAll(".edit-card")).toHaveLength(2);
+    expect(el.shadowRoot.querySelector(".tab-card-json")).toBeNull();
+    expect(el.shadowRoot.querySelector("hui-card-element-editor")).toBeNull();
   });
 
-  it("does not emit when the card JSON is invalid", async () => {
+  it("drills into the native card editor with the tab's card as its value", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown", content: "hi" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    // tab list is hidden while editing a card
+    expect(el.shadowRoot.querySelector(".tabs")).toBeNull();
+    const inner = el.shadowRoot.querySelector("hui-card-element-editor") as any;
+    expect(inner).toBeTruthy();
+    expect(inner.value).toEqual({ type: "markdown", content: "hi" });
+    expect(inner._hass).toEqual({ states: {} });
+    expect(inner._lovelace).toBeTruthy();
+  });
+
+  it("patches the tab card and re-emits the full config on the inner editor's config-changed", async () => {
     const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
     const handler = vi.fn();
     el.addEventListener("config-changed", handler);
-    const ta = el.shadowRoot.querySelector(".tab-card-json");
-    ta.value = "{ not valid json";
-    ta.dispatchEvent(new Event("change"));
+    const inner = el.shadowRoot.querySelector("hui-card-element-editor") as any;
+    inner.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: { config: { type: "light", entity: "light.kitchen" } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    const cfg = handler.mock.calls.at(-1)[0].detail.config;
+    // full tabdeck config is emitted, not the bare card config
+    expect(cfg.tabs).toHaveLength(1);
+    expect(cfg.tabs[0].card).toEqual({ type: "light", entity: "light.kitchen" });
+  });
+
+  it("returns to the tab list when Back is pressed", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
     await el.updateComplete;
-    expect(handler).not.toHaveBeenCalled();
-    expect(el.shadowRoot.querySelector(".tab-card-error")).toBeTruthy();
+    expect(el.shadowRoot.querySelector(".back-to-list")).toBeTruthy();
+    el.shadowRoot.querySelector(".back-to-list").click();
+    await el.updateComplete;
+    expect(el.shadowRoot.querySelector(".tabs")).toBeTruthy();
+    expect(el.shadowRoot.querySelector("hui-card-element-editor")).toBeNull();
   });
 
   it("changes the global default_tab", async () => {

--- a/src/editor/tabdeck-card-editor.ts
+++ b/src/editor/tabdeck-card-editor.ts
@@ -1,16 +1,36 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { fireEvent } from "custom-card-helpers";
 import type { HomeAssistant } from "../types";
 import { normalizeConfig, type TabdeckCardConfig } from "../lib/config";
 
+export type CardEditorTag =
+  | "hui-card-element-editor"
+  | "ha-yaml-editor"
+  | "textarea-json";
+
+// Decide which nested card editor to use. Prefer Home Assistant's own
+// hui-card-element-editor (visual + per-card YAML toggle + card picker); fall
+// back to ha-yaml-editor, then to a raw JSON textarea, so the editor never
+// hard-fails on an HA version that lacks the internal element.
+export function pickCardEditorTag(has: (tag: string) => boolean): CardEditorTag {
+  if (has("hui-card-element-editor")) return "hui-card-element-editor";
+  if (has("ha-yaml-editor")) return "ha-yaml-editor";
+  return "textarea-json";
+}
+
 @customElement("tabdeck-card-editor")
 export class TabdeckCardEditor extends LitElement {
   @state() private _config?: TabdeckCardConfig;
+  // Index of the tab currently being edited in the drill-in card view, or null
+  // for the tab-list view.
+  @state() private _editingTab: number | null = null;
   // Index of the tab whose card JSON failed to parse, so we can show an error
   // without discarding what the user is typing.
   @state() private _cardError: number | null = null;
   public hass?: HomeAssistant;
+  // Set by Home Assistant's card-editor dialog; forwarded to the nested editor.
+  public lovelace?: any;
 
   setConfig(config: any): void {
     this._config = normalizeConfig(config);
@@ -71,9 +91,96 @@ export class TabdeckCardEditor extends LitElement {
     this._emit({ ...this._config, tabs });
   }
 
+  private _openCard(index: number): void {
+    this._cardError = null;
+    this._editingTab = index;
+  }
+
+  private _closeCard(): void {
+    this._editingTab = null;
+  }
+
+  private get _lovelace(): any {
+    return this.lovelace ?? { config: { views: [] }, editMode: true };
+  }
+
+  private _onNativeCardChanged(index: number, e: CustomEvent): void {
+    e.stopPropagation();
+    const config = (e.detail as any)?.config;
+    if (!config) return;
+    this._patchTab(index, { card: config });
+  }
+
+  private _onYamlCardChanged(index: number, e: CustomEvent): void {
+    e.stopPropagation();
+    const detail = e.detail as any;
+    if (detail?.isValid === false) return;
+    if (detail?.value === undefined) return;
+    this._patchTab(index, { card: detail.value });
+  }
+
   render() {
     if (!this._config) return html``;
-    const cfg = this._config;
+    if (this._editingTab !== null) return this._renderCardView(this._editingTab);
+    return this._renderListView();
+  }
+
+  private _renderCardView(index: number) {
+    const tab = this._config!.tabs[index];
+    if (!tab) {
+      // Tab vanished (e.g. deleted elsewhere) — bail back to the list.
+      this._editingTab = null;
+      return this._renderListView();
+    }
+    const tag = pickCardEditorTag((t) => !!customElements.get(t));
+    return html`
+      <div class="card-editor-view">
+        <div class="card-editor-header">
+          <button class="back-to-list" @click=${this._closeCard}>← Back</button>
+          <span class="card-editor-title">${tab.name || `Tab ${index + 1}`}</span>
+        </div>
+        ${this._renderCardEditor(index, tab, tag)}
+      </div>
+    `;
+  }
+
+  private _renderCardEditor(index: number, tab: any, tag: CardEditorTag) {
+    if (tag === "hui-card-element-editor") {
+      return html`
+        <hui-card-element-editor
+          .hass=${this.hass}
+          .lovelace=${this._lovelace}
+          .value=${tab.card ?? {}}
+          @config-changed=${(e: CustomEvent) => this._onNativeCardChanged(index, e)}
+        ></hui-card-element-editor>
+      `;
+    }
+    if (tag === "ha-yaml-editor") {
+      return html`
+        <ha-yaml-editor
+          .defaultValue=${tab.card ?? {}}
+          @value-changed=${(e: CustomEvent) => this._onYamlCardChanged(index, e)}
+        ></ha-yaml-editor>
+      `;
+    }
+    return html`
+      <label class="card-label"
+        >Card (JSON)
+        <textarea
+          class="tab-card-json"
+          rows="10"
+          .value=${JSON.stringify(tab.card ?? {}, null, 2)}
+          @change=${(e: any) => this._editCardJson(index, e.target.value)}
+        ></textarea>
+      </label>
+      ${this._cardError === index
+        ? html`<div class="tab-card-error">Invalid JSON — not saved.</div>`
+        : nothing}
+    `;
+  }
+
+  private _renderListView() {
+    const cfg = this._config!;
     return html`
       <div class="editor">
         <div class="globals">
@@ -193,18 +300,11 @@ export class TabdeckCardEditor extends LitElement {
                       this._patchTab(index, { badge: e.target.value || undefined })}
                   />
                 </div>
-                <label class="card-label"
-                  >Card (JSON)
-                  <textarea
-                    class="tab-card-json"
-                    rows="6"
-                    .value=${JSON.stringify(tab.card ?? {}, null, 2)}
-                    @change=${(e: any) => this._editCardJson(index, e.target.value)}
-                  ></textarea>
-                </label>
-                ${this._cardError === index
-                  ? html`<div class="tab-card-error">Invalid JSON — not saved.</div>`
-                  : ""}
+                <button class="edit-card" @click=${() => this._openCard(index)}>
+                  <span class="edit-card-label">Edit card</span>
+                  <span class="edit-card-type">${tab.card?.type ?? "—"}</span>
+                  <span class="edit-card-arrow">→</span>
+                </button>
               </div>
             `,
           )}
@@ -254,6 +354,44 @@ export class TabdeckCardEditor extends LitElement {
     .tab-accent,
     .tab-badge {
       flex: 1;
+    }
+    .edit-card {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 8px 12px;
+      background: var(--secondary-background-color, #f5f5f5);
+      border: 1px solid var(--divider-color, #e0e0e0);
+      border-radius: 6px;
+      font-size: 13px;
+      text-align: left;
+    }
+    .edit-card-type {
+      color: var(--secondary-text-color);
+      font-family: var(--code-font-family, monospace);
+      font-size: 12px;
+    }
+    .edit-card-arrow {
+      margin-left: auto;
+      color: var(--secondary-text-color);
+    }
+    .card-editor-view {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .card-editor-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .card-editor-title {
+      font-weight: 500;
+    }
+    .back-to-list {
+      cursor: pointer;
     }
     .card-label {
       font-size: 12px;

--- a/src/editor/tabdeck-card-editor.yaml.test.ts
+++ b/src/editor/tabdeck-card-editor.yaml.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import "./tabdeck-card-editor";
+
+// In this file ha-yaml-editor IS registered but hui-card-element-editor is NOT,
+// so the editor must fall back to ha-yaml-editor for nested card editing.
+beforeAll(() => {
+  if (!customElements.get("ha-yaml-editor")) {
+    customElements.define(
+      "ha-yaml-editor",
+      class extends HTMLElement {
+        _defaultValue: any;
+        set defaultValue(v: any) {
+          this._defaultValue = v;
+        }
+        get defaultValue() {
+          return this._defaultValue;
+        }
+      },
+    );
+  }
+});
+
+async function mount(config: any) {
+  const el = document.createElement("tabdeck-card-editor") as any;
+  el.hass = { states: {} };
+  el.setConfig(config);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("tabdeck-card-editor ha-yaml-editor fallback", () => {
+  it("drills into ha-yaml-editor seeded with the tab's card", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown", content: "hi" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    const yaml = el.shadowRoot.querySelector("ha-yaml-editor") as any;
+    expect(yaml).toBeTruthy();
+    expect(yaml.defaultValue).toEqual({ type: "markdown", content: "hi" });
+    expect(el.shadowRoot.querySelector("hui-card-element-editor")).toBeNull();
+  });
+
+  it("patches the tab card on ha-yaml-editor value-changed (valid yaml)", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    const handler = vi.fn();
+    el.addEventListener("config-changed", handler);
+    const yaml = el.shadowRoot.querySelector("ha-yaml-editor") as any;
+    yaml.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { type: "light", entity: "light.kitchen" }, isValid: true },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls.at(-1)[0].detail.config.tabs[0].card).toEqual({
+      type: "light",
+      entity: "light.kitchen",
+    });
+  });
+
+  it("ignores ha-yaml-editor value-changed when invalid", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: { type: "markdown" } }] });
+    el.shadowRoot.querySelector(".edit-card").click();
+    await el.updateComplete;
+    const handler = vi.fn();
+    el.addEventListener("config-changed", handler);
+    const yaml = el.shadowRoot.querySelector("ha-yaml-editor") as any;
+    yaml.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: undefined, isValid: false },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Replaces the per-tab raw JSON textarea with a drill-in card editor.

- Prefers HA `hui-card-element-editor` (visual + per-card YAML toggle + card picker)
- Falls back to `ha-yaml-editor`, then a JSON textarea, so it never hard-fails across HA versions
- Inner config-changed/value-changed events are stopped and re-emitted as the full tabdeck config
- 19 editor tests across primary + both fallback paths; full suite 64/64, typecheck + build clean