### PR TITLE
Template support for tab badges and visibility conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,13 @@ tabs:
 | `name`       | string | —       | Tab label; also the id used by `default_tab` and `#tab=`. |
 | `icon`       | string | —       | Optional `mdi:` icon. |
 | `accent`     | string | —       | Optional per-tab accent color (any CSS color). |
-| `badge`      | string | —       | Entity id whose state is shown as a badge. |
+| `badge`      | string | —       | Entity id whose state is shown as a badge, or a Jinja template (e.g. `{{ states('sensor.unread') }}`). |
 | `visibility` | list   | —       | Conditions (see below); the tab is hidden when unmet. |
 | `card`       | object | —       | Any Lovelace card config (required). |
 
 ### Visibility conditions
 
-Supported condition types in v1: `state`, `numeric_state`, and `screen`.
-(Template conditions are planned for a later release.)
+Supported condition types: `state`, `numeric_state`, `screen`, and `template`.
 
 ```yaml
 visibility:
@@ -118,7 +117,16 @@ visibility:
     entity: sensor.temperature
     above: 18
     below: 26
+  - condition: template
+    value_template: "{{ is_state('alarm_control_panel.home', 'armed_away') }}"
 ```
+
+### Templates
+
+Both `badge` and `template` visibility conditions accept Jinja templates,
+rendered server-side by Home Assistant and updated live. A tab with a
+template visibility condition stays hidden until the template first renders
+truthy (and is hidden again if the template errors).
 
 ## Theming
 

--- a/dist/tabdeck-card.js
+++ b/dist/tabdeck-card.js
@@ -669,7 +669,11 @@ function checkScreen(c2) {
   if (!c2.media_query || typeof matchMedia !== "function") return false;
   return matchMedia(c2.media_query).matches;
 }
-function checkOne(c2, hass) {
+function checkTemplate(c2, resolver) {
+  if (!resolver || !c2.value_template) return false;
+  return resolver(c2.value_template) === true;
+}
+function checkOne(c2, hass, resolver) {
   switch (c2 == null ? void 0 : c2.condition) {
     case "state":
       return checkState(c2, hass);
@@ -677,14 +681,16 @@ function checkOne(c2, hass) {
       return checkNumeric(c2, hass);
     case "screen":
       return checkScreen(c2);
+    case "template":
+      return checkTemplate(c2, resolver);
     default:
       return false;
   }
 }
-function isTabVisible(visibility, hass) {
+function isTabVisible(visibility, hass, templateResolver) {
   if (!visibility || visibility.length === 0) return true;
   if (!hass) return true;
-  return visibility.every((c2) => checkOne(c2, hass));
+  return visibility.every((c2) => checkOne(c2, hass, templateResolver));
 }
 function storageKey(cardKey) {
   return "tabdeck-card:" + cardKey;
@@ -772,6 +778,71 @@ class CardManager extends EventTarget {
     if (this._hass) fresh.hass = this._hass;
     this._elements[index] = fresh;
     this.dispatchEvent(new CustomEvent("ll-rebuild-done", { detail: { index } }));
+  }
+}
+function isTemplate(s2) {
+  return !!s2 && (s2.includes("{{") || s2.includes("{%"));
+}
+function asBool(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    return ["1", "true", "yes", "on", "enable"].includes(value.trim().toLowerCase());
+  }
+  return false;
+}
+class TemplateRenderer extends EventTarget {
+  constructor(subscribe) {
+    super();
+    this._entries = /* @__PURE__ */ new Map();
+    this._subscribe = subscribe;
+  }
+  // Reconcile live subscriptions with the desired set of template strings.
+  track(templates) {
+    const desired = new Set(templates.filter((t2) => !!t2));
+    for (const [tpl, entry] of this._entries) {
+      if (!desired.has(tpl)) {
+        entry.unsub();
+        this._entries.delete(tpl);
+      }
+    }
+    for (const tpl of desired) {
+      if (this._entries.has(tpl)) continue;
+      const entry = { unsub: () => {
+      }, hasResult: false, error: false };
+      this._entries.set(tpl, entry);
+      entry.unsub = this._subscribe(
+        tpl,
+        (result) => {
+          entry.result = result;
+          entry.hasResult = true;
+          entry.error = false;
+          this.dispatchEvent(new CustomEvent("change", { detail: { template: tpl } }));
+        },
+        () => {
+          entry.error = true;
+          entry.hasResult = false;
+          entry.result = void 0;
+          this.dispatchEvent(new CustomEvent("change", { detail: { template: tpl } }));
+        }
+      );
+    }
+  }
+  // Latest rendered value, or undefined while pending or errored.
+  result(tpl) {
+    const e2 = this._entries.get(tpl);
+    if (!e2 || e2.error || !e2.hasResult) return void 0;
+    return e2.result;
+  }
+  // Fail-closed boolean: false until a truthy value has rendered.
+  boolean(tpl) {
+    const e2 = this._entries.get(tpl);
+    if (!e2 || e2.error || !e2.hasResult) return false;
+    return asBool(e2.result);
+  }
+  destroy() {
+    for (const e2 of this._entries.values()) e2.unsub();
+    this._entries.clear();
   }
 }
 var __defProp$3 = Object.defineProperty;
@@ -1051,6 +1122,10 @@ let TabdeckCard = class extends i {
     this._selected = 0;
     this._built = false;
     this._cardKey = "";
+    this._templateResolver = (tpl) => {
+      var _a2;
+      return (_a2 = this._templates) == null ? void 0 : _a2.boolean(tpl);
+    };
   }
   static getStubConfig() {
     return {
@@ -1065,11 +1140,20 @@ let TabdeckCard = class extends i {
     return document.createElement("tabdeck-card-editor");
   }
   setConfig(raw) {
+    var _a2;
     this._config = normalizeConfig(raw);
     this._cardKey = this._computeCardKey(this._config);
     this._built = false;
     this._selected = resolveDefaultIndex(this._config);
+    (_a2 = this._templates) == null ? void 0 : _a2.destroy();
+    this._templates = void 0;
     void this._build();
+  }
+  disconnectedCallback() {
+    var _a2;
+    super.disconnectedCallback();
+    (_a2 = this._templates) == null ? void 0 : _a2.destroy();
+    this._templates = void 0;
   }
   _computeCardKey(cfg) {
     const path = typeof location !== "undefined" ? location.pathname : "";
@@ -1083,6 +1167,7 @@ let TabdeckCard = class extends i {
     this._manager.addEventListener("ll-rebuild-done", () => this.requestUpdate());
     await this._manager.build(this._config.tabs.map((t2) => t2.card));
     if (this._hass) this._manager.setHass(this._hass);
+    this._syncTemplates();
     this._selected = loadInitialIndex({
       mode: this._config.remember,
       cardKey: this._cardKey,
@@ -1098,6 +1183,7 @@ let TabdeckCard = class extends i {
     var _a2;
     this._hass = hass;
     (_a2 = this._manager) == null ? void 0 : _a2.setHass(hass);
+    this._syncTemplates();
     this.requestUpdate();
   }
   get hass() {
@@ -1105,7 +1191,67 @@ let TabdeckCard = class extends i {
   }
   _visibleTabs() {
     if (!this._config) return [];
-    return this._config.tabs.filter((t2) => isTabVisible(t2.visibility, this._hass));
+    return this._config.tabs.filter(
+      (t2) => isTabVisible(t2.visibility, this._hass, this._templateResolver)
+    );
+  }
+  _collectTemplates() {
+    if (!this._config) return [];
+    const out = [];
+    for (const t2 of this._config.tabs) {
+      if (isTemplate(t2.badge)) out.push(t2.badge);
+      for (const c2 of t2.visibility ?? []) {
+        if ((c2 == null ? void 0 : c2.condition) === "template" && c2.value_template) out.push(c2.value_template);
+      }
+    }
+    return out;
+  }
+  _makeSubscribe() {
+    var _a2, _b;
+    if (!((_b = (_a2 = this._hass) == null ? void 0 : _a2.connection) == null ? void 0 : _b.subscribeMessage)) return void 0;
+    return (template, onResult, onError) => {
+      var _a3;
+      const conn = (_a3 = this._hass) == null ? void 0 : _a3.connection;
+      if (!(conn == null ? void 0 : conn.subscribeMessage)) {
+        onError();
+        return () => {
+        };
+      }
+      let unsubbed = false;
+      let realUnsub;
+      Promise.resolve(
+        conn.subscribeMessage(
+          (msg) => {
+            if (msg && msg.error !== void 0) onError();
+            else onResult(msg == null ? void 0 : msg.result);
+          },
+          { type: "render_template", template, report_errors: true }
+        )
+      ).then((u2) => {
+        realUnsub = u2;
+        if (unsubbed) u2 == null ? void 0 : u2();
+      }).catch(() => onError());
+      return () => {
+        unsubbed = true;
+        realUnsub == null ? void 0 : realUnsub();
+      };
+    };
+  }
+  _syncTemplates() {
+    var _a2;
+    const templates = this._collectTemplates();
+    if (templates.length === 0) {
+      (_a2 = this._templates) == null ? void 0 : _a2.destroy();
+      this._templates = void 0;
+      return;
+    }
+    if (!this._templates) {
+      const subscribe = this._makeSubscribe();
+      if (!subscribe) return;
+      this._templates = new TemplateRenderer(subscribe);
+      this._templates.addEventListener("change", () => this.requestUpdate());
+    }
+    this._templates.track(templates);
   }
   getCardSize() {
     var _a2;
@@ -1187,7 +1333,13 @@ let TabdeckCard = class extends i {
     `;
   }
   _resolveBadge(badge) {
-    if (!badge || !this._hass) return void 0;
+    var _a2;
+    if (!badge) return void 0;
+    if (isTemplate(badge)) {
+      const r2 = (_a2 = this._templates) == null ? void 0 : _a2.result(badge);
+      return r2 === void 0 || r2 === null ? void 0 : String(r2);
+    }
+    if (!this._hass) return void 0;
     const stateObj = this._hass.states[badge];
     if (stateObj) return stateObj.state;
     return badge;
@@ -1507,7 +1659,7 @@ let TabdeckCardEditor = class extends i {
                     class="tab-badge"
                     type="text"
                     .value=${tab.badge ?? ""}
-                    placeholder="Badge entity (e.g. sensor.unread)"
+                    placeholder="Badge: sensor.unread or {{ template }}"
                     @input=${(e2) => this._patchTab(index, { badge: e2.target.value || void 0 })}
                   />
                 </div>

--- a/src/editor/tabdeck-card-editor.ts
+++ b/src/editor/tabdeck-card-editor.ts
@@ -295,7 +295,7 @@ export class TabdeckCardEditor extends LitElement {
                     class="tab-badge"
                     type="text"
                     .value=${tab.badge ?? ""}
-                    placeholder="Badge entity (e.g. sensor.unread)"
+                    placeholder="Badge: sensor.unread or {{ template }}"
                     @input=${(e: any) =>
                       this._patchTab(index, { badge: e.target.value || undefined })}
                   />

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -88,4 +88,34 @@ describe("isTabVisible", () => {
     ).toBe(false);
     vi.unstubAllGlobals();
   });
+
+  describe("template conditions", () => {
+    const tpl = { condition: "template", value_template: "{{ true }}" };
+
+    it("consults the resolver for a template condition", () => {
+      const hass = hassWith({});
+      expect(isTabVisible([tpl], hass, () => true)).toBe(true);
+      expect(isTabVisible([tpl], hass, () => false)).toBe(false);
+    });
+
+    it("fails closed when the resolver returns undefined (pending)", () => {
+      const hass = hassWith({});
+      expect(isTabVisible([tpl], hass, () => undefined)).toBe(false);
+    });
+
+    it("fails closed when a template condition has no resolver", () => {
+      const hass = hassWith({});
+      expect(isTabVisible([tpl], hass)).toBe(false);
+    });
+
+    it("combines template and state conditions (ALL must pass)", () => {
+      const hass = hassWith({ "input_boolean.a": { state: "on" } });
+      const conds = [
+        { condition: "state", entity: "input_boolean.a", state: "on" },
+        tpl,
+      ];
+      expect(isTabVisible(conds, hass, () => true)).toBe(true);
+      expect(isTabVisible(conds, hass, () => false)).toBe(false);
+    });
+  });
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -29,7 +29,16 @@ function checkScreen(c: any): boolean {
   return matchMedia(c.media_query).matches;
 }
 
-function checkOne(c: any, hass: HomeAssistant): boolean {
+// Resolves a `template` condition's value_template to a rendered boolean, or
+// undefined while the template is still pending (treated as not met).
+export type TemplateResolver = (valueTemplate: string) => boolean | undefined;
+
+function checkTemplate(c: any, resolver?: TemplateResolver): boolean {
+  if (!resolver || !c.value_template) return false;
+  return resolver(c.value_template) === true;
+}
+
+function checkOne(c: any, hass: HomeAssistant, resolver?: TemplateResolver): boolean {
   switch (c?.condition) {
     case "state":
       return checkState(c, hass);
@@ -37,6 +46,8 @@ function checkOne(c: any, hass: HomeAssistant): boolean {
       return checkNumeric(c, hass);
     case "screen":
       return checkScreen(c);
+    case "template":
+      return checkTemplate(c, resolver);
     default:
       return false;
   }
@@ -45,8 +56,9 @@ function checkOne(c: any, hass: HomeAssistant): boolean {
 export function isTabVisible(
   visibility: any[] | undefined,
   hass: HomeAssistant | undefined,
+  templateResolver?: TemplateResolver,
 ): boolean {
   if (!visibility || visibility.length === 0) return true;
   if (!hass) return true;
-  return visibility.every((c) => checkOne(c, hass));
+  return visibility.every((c) => checkOne(c, hass, templateResolver));
 }

--- a/src/lib/templates.test.ts
+++ b/src/lib/templates.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { isTemplate, TemplateRenderer, type SubscribeFn } from "./templates";
+
+describe("isTemplate", () => {
+  it("detects {{ }} and {% %} markers", () => {
+    expect(isTemplate("{{ states('sensor.x') }}")).toBe(true);
+    expect(isTemplate("{% if true %}1{% endif %}")).toBe(true);
+  });
+  it("treats plain strings and entity ids as non-templates", () => {
+    expect(isTemplate("sensor.unread")).toBe(false);
+    expect(isTemplate("5")).toBe(false);
+    expect(isTemplate(undefined as any)).toBe(false);
+  });
+});
+
+// A controllable fake subscribe adapter: records subscriptions and lets the
+// test push results/errors and observe unsubscribes.
+function fakeSubscribe() {
+  const subs = new Map<string, any>();
+  const subscribe: SubscribeFn = (template, onResult, onError) => {
+    const unsub = vi.fn();
+    subs.set(template, { onResult, onError, unsub });
+    return unsub;
+  };
+  return { subscribe, subs };
+}
+
+describe("TemplateRenderer", () => {
+  it("subscribes to each tracked template once", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ a }}", "{{ b }}", "{{ a }}"]);
+    expect([...subs.keys()].sort()).toEqual(["{{ a }}", "{{ b }}"]);
+  });
+
+  it("caches results and reports them via result()", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ a }}"]);
+    expect(r.result("{{ a }}")).toBeUndefined();
+    subs.get("{{ a }}")!.onResult("42");
+    expect(r.result("{{ a }}")).toBe("42");
+  });
+
+  it("emits a change event when a result arrives", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    const onChange = vi.fn();
+    r.addEventListener("change", onChange);
+    r.track(["{{ a }}"]);
+    subs.get("{{ a }}")!.onResult("x");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("boolean() is fail-closed until a truthy result renders", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ a }}"]);
+    expect(r.boolean("{{ a }}")).toBe(false); // pending
+    subs.get("{{ a }}")!.onResult(true);
+    expect(r.boolean("{{ a }}")).toBe(true);
+    subs.get("{{ a }}")!.onResult("off");
+    expect(r.boolean("{{ a }}")).toBe(false); // HA renders booleans as "off"/"on" strings
+    subs.get("{{ a }}")!.onResult("on");
+    expect(r.boolean("{{ a }}")).toBe(true);
+  });
+
+  it("treats errors as fail-closed", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ bad }}"]);
+    subs.get("{{ bad }}")!.onResult(true);
+    expect(r.boolean("{{ bad }}")).toBe(true);
+    subs.get("{{ bad }}")!.onError();
+    expect(r.boolean("{{ bad }}")).toBe(false);
+    expect(r.result("{{ bad }}")).toBeUndefined();
+  });
+
+  it("unsubscribes templates dropped from the tracked set", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ a }}", "{{ b }}"]);
+    const aUnsub = subs.get("{{ a }}")!.unsub;
+    r.track(["{{ b }}"]);
+    expect(aUnsub).toHaveBeenCalledTimes(1);
+    expect(r.result("{{ a }}")).toBeUndefined();
+  });
+
+  it("destroy() unsubscribes everything", () => {
+    const { subscribe, subs } = fakeSubscribe();
+    const r = new TemplateRenderer(subscribe);
+    r.track(["{{ a }}", "{{ b }}"]);
+    const unsubs = [...subs.values()].map((s) => s.unsub);
+    r.destroy();
+    for (const u of unsubs) expect(u).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,94 @@
+// Server-side Jinja template rendering for badges and visibility conditions.
+// Home Assistant renders templates over the websocket (`render_template`), so
+// results arrive asynchronously. This module owns the subscription bookkeeping
+// and caches the latest rendered value per template, fail-closed until rendered.
+
+export type SubscribeFn = (
+  template: string,
+  onResult: (result: any) => void,
+  onError: () => void,
+) => () => void;
+
+export function isTemplate(s: string | undefined): boolean {
+  return !!s && (s.includes("{{") || s.includes("{%"));
+}
+
+// Mirrors Home Assistant's `result_as_boolean`: booleans pass through, numbers
+// are truthy when non-zero, strings match HA's truthy token set.
+function asBool(value: any): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    return ["1", "true", "yes", "on", "enable"].includes(value.trim().toLowerCase());
+  }
+  return false;
+}
+
+interface Entry {
+  unsub: () => void;
+  result?: any;
+  hasResult: boolean;
+  error: boolean;
+}
+
+export class TemplateRenderer extends EventTarget {
+  private _subscribe: SubscribeFn;
+  private _entries = new Map<string, Entry>();
+
+  constructor(subscribe: SubscribeFn) {
+    super();
+    this._subscribe = subscribe;
+  }
+
+  // Reconcile live subscriptions with the desired set of template strings.
+  track(templates: string[]): void {
+    const desired = new Set(templates.filter((t) => !!t));
+
+    for (const [tpl, entry] of this._entries) {
+      if (!desired.has(tpl)) {
+        entry.unsub();
+        this._entries.delete(tpl);
+      }
+    }
+
+    for (const tpl of desired) {
+      if (this._entries.has(tpl)) continue;
+      const entry: Entry = { unsub: () => {}, hasResult: false, error: false };
+      this._entries.set(tpl, entry);
+      entry.unsub = this._subscribe(
+        tpl,
+        (result) => {
+          entry.result = result;
+          entry.hasResult = true;
+          entry.error = false;
+          this.dispatchEvent(new CustomEvent("change", { detail: { template: tpl } }));
+        },
+        () => {
+          entry.error = true;
+          entry.hasResult = false;
+          entry.result = undefined;
+          this.dispatchEvent(new CustomEvent("change", { detail: { template: tpl } }));
+        },
+      );
+    }
+  }
+
+  // Latest rendered value, or undefined while pending or errored.
+  result(tpl: string): any {
+    const e = this._entries.get(tpl);
+    if (!e || e.error || !e.hasResult) return undefined;
+    return e.result;
+  }
+
+  // Fail-closed boolean: false until a truthy value has rendered.
+  boolean(tpl: string): boolean {
+    const e = this._entries.get(tpl);
+    if (!e || e.error || !e.hasResult) return false;
+    return asBool(e.result);
+  }
+
+  destroy(): void {
+    for (const e of this._entries.values()) e.unsub();
+    this._entries.clear();
+  }
+}

--- a/src/tabdeck-card.test.ts
+++ b/src/tabdeck-card.test.ts
@@ -97,3 +97,96 @@ describe("tabdeck-card", () => {
     expect(entry.preview).toBe(true);
   });
 });
+
+// A hass with a controllable render_template subscription, so tests can push
+// rendered values synchronously.
+function hassWithTemplates() {
+  const subs: any[] = [];
+  const hass = {
+    states: {},
+    connection: {
+      subscribeMessage: (cb: any, msg: any) => {
+        subs.push({ cb, template: msg.template });
+        return Promise.resolve(() => {});
+      },
+    },
+  };
+  const push = (match: string, message: any) => {
+    for (const s of subs) if (s.template.includes(match)) s.cb(message);
+  };
+  return { hass, subs, push };
+}
+
+async function mountWith(raw: any, hass: any) {
+  await import("./tabdeck-card");
+  const el = document.createElement("tabdeck-card") as any;
+  el.setConfig(raw);
+  document.body.appendChild(el);
+  el.hass = hass;
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+  return el;
+}
+
+describe("tabdeck-card templates", () => {
+  it("renders a badge from a template once it resolves", async () => {
+    const { hass, push } = hassWithTemplates();
+    const el = await mountWith(
+      { tabs: [{ name: "A", badge: "{{ states('sensor.x') }}", card: { type: "markdown" } }] },
+      hass,
+    );
+    const bar = () => el.shadowRoot.querySelector("tabdeck-tabbar");
+    expect(bar().items[0].badge).toBeUndefined();
+    push("sensor.x", { result: "7" });
+    await el.updateComplete;
+    expect(bar().items[0].badge).toBe("7");
+  });
+
+  it("hides a tab with a template condition until it renders true", async () => {
+    const { hass, push } = hassWithTemplates();
+    const el = await mountWith(
+      {
+        tabs: [
+          { name: "A", card: { type: "markdown" } },
+          {
+            name: "B",
+            card: { type: "light" },
+            visibility: [{ condition: "template", value_template: "{{ is_state('x.y','on') }}" }],
+          },
+        ],
+      },
+      hass,
+    );
+    const bar = () => el.shadowRoot.querySelector("tabdeck-tabbar");
+    expect(bar().items).toHaveLength(1);
+    expect(bar().items[0].name).toBe("A");
+    push("x.y", { result: "on" });
+    await el.updateComplete;
+    expect(bar().items).toHaveLength(2);
+  });
+
+  it("treats a template error as fail-closed for visibility", async () => {
+    const { hass, push } = hassWithTemplates();
+    const el = await mountWith(
+      {
+        tabs: [
+          { name: "A", card: { type: "markdown" } },
+          {
+            name: "B",
+            card: { type: "light" },
+            visibility: [{ condition: "template", value_template: "{{ broken " }],
+          },
+        ],
+      },
+      hass,
+    );
+    const bar = () => el.shadowRoot.querySelector("tabdeck-tabbar");
+    push("broken", { result: "on" });
+    await el.updateComplete;
+    expect(bar().items).toHaveLength(2);
+    push("broken", { error: "TemplateError: bad" });
+    await el.updateComplete;
+    expect(bar().items).toHaveLength(1);
+  });
+});

--- a/src/tabdeck-card.ts
+++ b/src/tabdeck-card.ts
@@ -9,6 +9,7 @@ import {
 import { isTabVisible } from "./lib/conditions";
 import { loadInitialIndex, persistIndex } from "./lib/persistence";
 import { CardManager, getCreateCardElement } from "./lib/card-lifecycle";
+import { isTemplate, TemplateRenderer, type SubscribeFn } from "./lib/templates";
 import "./components/tabdeck-tabbar";
 
 @customElement("tabdeck-card")
@@ -19,6 +20,7 @@ export class TabdeckCard extends LitElement {
   private _hass?: HomeAssistant;
   private _manager?: CardManager;
   private _cardKey = "";
+  private _templates?: TemplateRenderer;
 
   static getStubConfig() {
     return {
@@ -39,7 +41,16 @@ export class TabdeckCard extends LitElement {
     this._cardKey = this._computeCardKey(this._config);
     this._built = false;
     this._selected = resolveDefaultIndex(this._config);
+    // Drop any subscriptions from a previous config; they re-sync on next hass.
+    this._templates?.destroy();
+    this._templates = undefined;
     void this._build();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._templates?.destroy();
+    this._templates = undefined;
   }
 
   private _computeCardKey(cfg: TabdeckCardConfig): string {
@@ -55,6 +66,7 @@ export class TabdeckCard extends LitElement {
     this._manager.addEventListener("ll-rebuild-done", () => this.requestUpdate());
     await this._manager.build(this._config.tabs.map((t) => t.card));
     if (this._hass) this._manager.setHass(this._hass);
+    this._syncTemplates();
     this._selected = loadInitialIndex({
       mode: this._config.remember,
       cardKey: this._cardKey,
@@ -70,6 +82,7 @@ export class TabdeckCard extends LitElement {
   set hass(hass: HomeAssistant) {
     this._hass = hass;
     this._manager?.setHass(hass);
+    this._syncTemplates();
     this.requestUpdate();
   }
 
@@ -77,9 +90,75 @@ export class TabdeckCard extends LitElement {
     return this._hass;
   }
 
+  // Resolves a `template` visibility condition's value_template to a rendered
+  // boolean (undefined while pending → fail-closed in isTabVisible).
+  private _templateResolver = (tpl: string): boolean | undefined =>
+    this._templates?.boolean(tpl);
+
   private _visibleTabs() {
     if (!this._config) return [];
-    return this._config.tabs.filter((t) => isTabVisible(t.visibility, this._hass));
+    return this._config.tabs.filter((t) =>
+      isTabVisible(t.visibility, this._hass, this._templateResolver),
+    );
+  }
+
+  private _collectTemplates(): string[] {
+    if (!this._config) return [];
+    const out: string[] = [];
+    for (const t of this._config.tabs) {
+      if (isTemplate(t.badge)) out.push(t.badge!);
+      for (const c of t.visibility ?? []) {
+        if (c?.condition === "template" && c.value_template) out.push(c.value_template);
+      }
+    }
+    return out;
+  }
+
+  private _makeSubscribe(): SubscribeFn | undefined {
+    if (!this._hass?.connection?.subscribeMessage) return undefined;
+    return (template, onResult, onError) => {
+      const conn = this._hass?.connection;
+      if (!conn?.subscribeMessage) {
+        onError();
+        return () => {};
+      }
+      let unsubbed = false;
+      let realUnsub: (() => void) | undefined;
+      Promise.resolve(
+        conn.subscribeMessage(
+          (msg: any) => {
+            if (msg && msg.error !== undefined) onError();
+            else onResult(msg?.result);
+          },
+          { type: "render_template", template, report_errors: true },
+        ),
+      )
+        .then((u: any) => {
+          realUnsub = u;
+          if (unsubbed) u?.();
+        })
+        .catch(() => onError());
+      return () => {
+        unsubbed = true;
+        realUnsub?.();
+      };
+    };
+  }
+
+  private _syncTemplates(): void {
+    const templates = this._collectTemplates();
+    if (templates.length === 0) {
+      this._templates?.destroy();
+      this._templates = undefined;
+      return;
+    }
+    if (!this._templates) {
+      const subscribe = this._makeSubscribe();
+      if (!subscribe) return; // no connection yet; retried on next hass
+      this._templates = new TemplateRenderer(subscribe);
+      this._templates.addEventListener("change", () => this.requestUpdate());
+    }
+    this._templates.track(templates);
   }
 
   getCardSize(): number {
@@ -163,7 +242,12 @@ export class TabdeckCard extends LitElement {
   }
 
   private _resolveBadge(badge?: string): string | undefined {
-    if (!badge || !this._hass) return undefined;
+    if (!badge) return undefined;
+    if (isTemplate(badge)) {
+      const r = this._templates?.result(badge);
+      return r === undefined || r === null ? undefined : String(r);
+    }
+    if (!this._hass) return undefined;
     const stateObj = this._hass.states[badge];
     if (stateObj) return stateObj.state;
     return badge;


### PR DESCRIPTION
Adds server-side Jinja template rendering for tab badges and a new `template` visibility condition.

- New `src/lib/templates.ts` TemplateRenderer (injectable subscribe adapter, cached results, fail-closed)
- `conditions.ts` gains the `template` condition via an optional resolver; state/numeric/screen unchanged
- Main card subscribes via `hass.connection` render_template, resolves badges + template visibility, tears down on disconnect/config change
- Editor badge placeholder hints template support; README updated
- 80/80 tests; verified on dev-HA (badge renders, `{{true}}` tab shows, `{{false}}` tab hidden, no console errors)