### PR TITLE
Opt-in swipe gestures to change tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ tabs:
 | `scrollable`  | `auto` \| boolean | `auto`       | Scroll the tab bar when tabs overflow. |
 | `remember`    | string            | `none`       | `none` \| `browser` \| `url`. |
 | `lazy`        | boolean           | `false`      | Create inactive tab cards on first visit instead of up front. |
+| `swipe`       | boolean           | `false`      | Change tabs by swiping left/right on the card body (touch devices). Off by default so it never hijacks gestures of interactive cards (maps, sliders). |
 | `styles`      | object            | `{}`         | CSS-variable overrides (see Theming). |
 
 ### Tab options

--- a/dist/tabdeck-card.js
+++ b/dist/tabdeck-card.js
@@ -632,6 +632,7 @@ function normalizeConfig(raw) {
     scrollable: (raw == null ? void 0 : raw.scrollable) === void 0 ? "auto" : raw.scrollable,
     remember: pick(raw == null ? void 0 : raw.remember, REMEMBER, "none"),
     lazy: Boolean(raw == null ? void 0 : raw.lazy),
+    swipe: Boolean(raw == null ? void 0 : raw.swipe),
     styles: (raw == null ? void 0 : raw.styles) ?? {},
     tabs: tabs.map(normalizeTab)
   };
@@ -844,6 +845,18 @@ class TemplateRenderer extends EventTarget {
     for (const e2 of this._entries.values()) e2.unsub();
     this._entries.clear();
   }
+}
+function detectSwipe(start, end, opts = {}) {
+  const minDistance = opts.minDistance ?? 50;
+  const maxDuration = opts.maxDuration ?? 800;
+  const ratio = opts.ratio ?? 1.5;
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const dt = end.t - start.t;
+  if (dt > maxDuration) return null;
+  if (Math.abs(dx) < minDistance) return null;
+  if (Math.abs(dx) < Math.abs(dy) * ratio) return null;
+  return dx < 0 ? "next" : "prev";
 }
 var __defProp$3 = Object.defineProperty;
 var __getOwnPropDesc$3 = Object.getOwnPropertyDescriptor;
@@ -1126,6 +1139,29 @@ let TabdeckCard = class extends i {
       var _a2;
       return (_a2 = this._templates) == null ? void 0 : _a2.boolean(tpl);
     };
+    this._onTouchStart = (e2) => {
+      var _a2;
+      if (!((_a2 = this._config) == null ? void 0 : _a2.swipe) || e2.touches.length !== 1) {
+        this._touchStart = void 0;
+        return;
+      }
+      const t2 = e2.touches[0];
+      this._touchStart = { x: t2.clientX, y: t2.clientY, t: e2.timeStamp };
+    };
+    this._onTouchEnd = (e2) => {
+      var _a2;
+      const start = this._touchStart;
+      this._touchStart = void 0;
+      if (!start || !((_a2 = this._config) == null ? void 0 : _a2.swipe)) return;
+      const t2 = e2.changedTouches[0];
+      if (!t2) return;
+      const dir = detectSwipe(start, { x: t2.clientX, y: t2.clientY, t: e2.timeStamp });
+      if (!dir) return;
+      const last = this._visibleTabs().length - 1;
+      const target = dir === "next" ? this._selected + 1 : this._selected - 1;
+      const clamped = Math.max(0, Math.min(last, target));
+      if (clamped !== this._selected) this._selectIndex(clamped);
+    };
   }
   static getStubConfig() {
     return {
@@ -1268,7 +1304,10 @@ let TabdeckCard = class extends i {
     return this._config ? this._config.tabs.indexOf(target) : 0;
   }
   _onSelect(e2) {
-    this._selected = e2.detail.index;
+    this._selectIndex(e2.detail.index);
+  }
+  _selectIndex(index) {
+    this._selected = index;
     const visible = this._visibleTabs();
     const tab = visible[this._selected];
     if (this._config) {
@@ -1314,7 +1353,13 @@ let TabdeckCard = class extends i {
       ></tabdeck-tabbar>
     `;
     const panels = b`
-      <div class="content" id="tabdeck-panel" role="tabpanel">
+      <div
+        class="content"
+        id="tabdeck-panel"
+        role="tabpanel"
+        @touchstart=${this._onTouchStart}
+        @touchend=${this._onTouchEnd}
+      >
         ${visible.map((tab, i2) => {
       var _a2;
       const original = cfg.tabs.indexOf(tab);
@@ -1619,6 +1664,15 @@ let TabdeckCardEditor = class extends i {
               @change=${(e2) => this._patch({ lazy: e2.target.checked })}
             />
             Lazy-mount inactive tabs
+          </label>
+          <label class="checkbox"
+            ><input
+              class="global-swipe"
+              type="checkbox"
+              .checked=${cfg.swipe}
+              @change=${(e2) => this._patch({ swipe: e2.target.checked })}
+            />
+            Swipe to change tabs (mobile)
           </label>
         </div>
 

--- a/src/editor/tabdeck-card-editor.ts
+++ b/src/editor/tabdeck-card-editor.ts
@@ -257,6 +257,15 @@ export class TabdeckCardEditor extends LitElement {
             />
             Lazy-mount inactive tabs
           </label>
+          <label class="checkbox"
+            ><input
+              class="global-swipe"
+              type="checkbox"
+              .checked=${cfg.swipe}
+              @change=${(e: any) => this._patch({ swipe: e.target.checked })}
+            />
+            Swipe to change tabs (mobile)
+          </label>
         </div>
 
         <div class="tabs">

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -9,6 +9,7 @@ describe("normalizeConfig", () => {
     expect(c.scrollable).toBe("auto");
     expect(c.remember).toBe("none");
     expect(c.lazy).toBe(false);
+    expect(c.swipe).toBe(false);
     expect(c.default_tab).toBe(0);
     expect(c.tabs).toHaveLength(1);
   });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,6 +21,7 @@ export interface TabdeckCardConfig {
   scrollable: "auto" | boolean;
   remember: RememberMode;
   lazy: boolean;
+  swipe: boolean;
   styles: Record<string, string>;
   tabs: TabdeckTabConfig[];
 }
@@ -59,6 +60,7 @@ export function normalizeConfig(raw: any): TabdeckCardConfig {
     scrollable: raw?.scrollable === undefined ? "auto" : raw.scrollable,
     remember: pick(raw?.remember, REMEMBER, "none"),
     lazy: Boolean(raw?.lazy),
+    swipe: Boolean(raw?.swipe),
     styles: raw?.styles ?? {},
     tabs: tabs.map(normalizeTab),
   };

--- a/src/lib/swipe.test.ts
+++ b/src/lib/swipe.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { detectSwipe } from "./swipe";
+
+const p = (x: number, y: number, t: number) => ({ x, y, t });
+
+describe("detectSwipe", () => {
+  it("detects a leftward swipe as 'next'", () => {
+    expect(detectSwipe(p(200, 100, 0), p(100, 110, 200))).toBe("next");
+  });
+
+  it("detects a rightward swipe as 'prev'", () => {
+    expect(detectSwipe(p(100, 100, 0), p(220, 105, 200))).toBe("prev");
+  });
+
+  it("returns null when the horizontal distance is below threshold", () => {
+    expect(detectSwipe(p(100, 100, 0), p(130, 100, 100))).toBeNull();
+  });
+
+  it("returns null when the gesture is mostly vertical", () => {
+    expect(detectSwipe(p(100, 100, 0), p(160, 300, 200))).toBeNull();
+  });
+
+  it("returns null when the gesture is too slow", () => {
+    expect(detectSwipe(p(200, 100, 0), p(100, 100, 2000))).toBeNull();
+  });
+
+  it("respects custom options", () => {
+    expect(detectSwipe(p(200, 100, 0), p(170, 100, 100), { minDistance: 20 })).toBe("next");
+  });
+});

--- a/src/lib/swipe.ts
+++ b/src/lib/swipe.ts
@@ -1,0 +1,35 @@
+// Pure horizontal-swipe detection for touch gestures. Kept separate from the
+// card so the threshold logic is unit-testable without synthesising DOM touch
+// events. A swipe only registers when it is fast enough, long enough, and
+// clearly more horizontal than vertical (so it never hijacks vertical scroll).
+
+export interface SwipePoint {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export interface SwipeOptions {
+  minDistance?: number;
+  maxDuration?: number;
+  ratio?: number;
+}
+
+export type SwipeDirection = "next" | "prev" | null;
+
+export function detectSwipe(
+  start: SwipePoint,
+  end: SwipePoint,
+  opts: SwipeOptions = {},
+): SwipeDirection {
+  const minDistance = opts.minDistance ?? 50;
+  const maxDuration = opts.maxDuration ?? 800;
+  const ratio = opts.ratio ?? 1.5;
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const dt = end.t - start.t;
+  if (dt > maxDuration) return null;
+  if (Math.abs(dx) < minDistance) return null;
+  if (Math.abs(dx) < Math.abs(dy) * ratio) return null;
+  return dx < 0 ? "next" : "prev";
+}

--- a/src/tabdeck-card.test.ts
+++ b/src/tabdeck-card.test.ts
@@ -190,3 +190,79 @@ describe("tabdeck-card templates", () => {
     expect(bar().items).toHaveLength(1);
   });
 });
+
+// Fire a synthetic swipe on the content host. dx<0 swipes left (=> next tab).
+function swipe(el: any, dx: number, dy = 5, dt = 200) {
+  const content = el.shadowRoot.querySelector(".content");
+  const startX = 200;
+  const start = new Event("touchstart", { bubbles: true }) as any;
+  start.touches = [{ clientX: startX, clientY: 100 }];
+  Object.defineProperty(start, "timeStamp", { value: 1000 });
+  content.dispatchEvent(start);
+  const end = new Event("touchend", { bubbles: true }) as any;
+  end.changedTouches = [{ clientX: startX + dx, clientY: 100 + dy }];
+  Object.defineProperty(end, "timeStamp", { value: 1000 + dt });
+  content.dispatchEvent(end);
+}
+
+describe("tabdeck-card swipe", () => {
+  const three = () => ({
+    swipe: true,
+    tabs: [
+      { name: "A", card: { type: "markdown" } },
+      { name: "B", card: { type: "light" } },
+      { name: "C", card: { type: "markdown" } },
+    ],
+  });
+  const selected = (el: any) =>
+    el.shadowRoot.querySelector("tabdeck-tabbar").selected;
+
+  it("advances to the next tab on a leftward swipe", async () => {
+    const el = await mount(three());
+    expect(selected(el)).toBe(0);
+    swipe(el, -120);
+    await el.updateComplete;
+    expect(selected(el)).toBe(1);
+  });
+
+  it("goes to the previous tab on a rightward swipe", async () => {
+    const el = await mount(three());
+    swipe(el, -120);
+    await el.updateComplete;
+    expect(selected(el)).toBe(1);
+    swipe(el, 120);
+    await el.updateComplete;
+    expect(selected(el)).toBe(0);
+  });
+
+  it("clamps at the first and last tabs (no wrap)", async () => {
+    const el = await mount(three());
+    swipe(el, 120); // already at first; rightward => prev
+    await el.updateComplete;
+    expect(selected(el)).toBe(0);
+    swipe(el, -120);
+    swipe(el, -120);
+    swipe(el, -120); // try to go past the last
+    await el.updateComplete;
+    expect(selected(el)).toBe(2);
+  });
+
+  it("does nothing when swipe is disabled (default)", async () => {
+    const el = await mount({
+      tabs: [
+        { name: "A", card: { type: "markdown" } },
+        { name: "B", card: { type: "light" } },
+      ],
+    });
+    swipe(el, -120);
+    await el.updateComplete;
+    expect(selected(el)).toBe(0);
+  });
+
+  it("ignores a mostly-vertical drag", async () => {
+    const el = await mount(three());
+    swipe(el, -120, 400);
+    await el.updateComplete;
+    expect(selected(el)).toBe(0);
+  });
+});

--- a/src/tabdeck-card.ts
+++ b/src/tabdeck-card.ts
@@ -10,6 +10,7 @@ import { isTabVisible } from "./lib/conditions";
 import { loadInitialIndex, persistIndex } from "./lib/persistence";
 import { CardManager, getCreateCardElement } from "./lib/card-lifecycle";
 import { isTemplate, TemplateRenderer, type SubscribeFn } from "./lib/templates";
+import { detectSwipe, type SwipePoint } from "./lib/swipe";
 import "./components/tabdeck-tabbar";
 
 @customElement("tabdeck-card")
@@ -178,7 +179,11 @@ export class TabdeckCard extends LitElement {
   }
 
   private _onSelect(e: CustomEvent<{ index: number }>): void {
-    this._selected = e.detail.index;
+    this._selectIndex(e.detail.index);
+  }
+
+  private _selectIndex(index: number): void {
+    this._selected = index;
     const visible = this._visibleTabs();
     const tab = visible[this._selected];
     if (this._config) {
@@ -196,6 +201,31 @@ export class TabdeckCard extends LitElement {
       this._manager?.notifyVisible(this._activeOriginalIndex()),
     );
   }
+
+  private _touchStart?: SwipePoint;
+
+  private _onTouchStart = (e: TouchEvent): void => {
+    if (!this._config?.swipe || e.touches.length !== 1) {
+      this._touchStart = undefined;
+      return;
+    }
+    const t = e.touches[0];
+    this._touchStart = { x: t.clientX, y: t.clientY, t: e.timeStamp };
+  };
+
+  private _onTouchEnd = (e: TouchEvent): void => {
+    const start = this._touchStart;
+    this._touchStart = undefined;
+    if (!start || !this._config?.swipe) return;
+    const t = e.changedTouches[0];
+    if (!t) return;
+    const dir = detectSwipe(start, { x: t.clientX, y: t.clientY, t: e.timeStamp });
+    if (!dir) return;
+    const last = this._visibleTabs().length - 1;
+    const target = dir === "next" ? this._selected + 1 : this._selected - 1;
+    const clamped = Math.max(0, Math.min(last, target));
+    if (clamped !== this._selected) this._selectIndex(clamped);
+  };
 
   protected updated(changed: PropertyValues): void {
     super.updated(changed);
@@ -223,7 +253,13 @@ export class TabdeckCard extends LitElement {
       ></tabdeck-tabbar>
     `;
     const panels = html`
-      <div class="content" id="tabdeck-panel" role="tabpanel">
+      <div
+        class="content"
+        id="tabdeck-panel"
+        role="tabpanel"
+        @touchstart=${this._onTouchStart}
+        @touchend=${this._onTouchEnd}
+      >
         ${visible.map((tab, i) => {
           const original = cfg.tabs.indexOf(tab);
           return html`


### PR DESCRIPTION
Adds a `swipe` config flag (default off). Horizontal swipe on the card body moves to the next/previous visible tab, clamped at the ends.

- New pure `src/lib/swipe.ts` detectSwipe() with horizontal-dominance, distance and duration guards
- Touch handlers on the content host; shares `_selectIndex` with tab clicks (persistence + notifyVisible)
- Editor toggle + README
- 91/91 tests; verified on dev-HA mobile viewport: left=>next, right=>prev, clamp at ends, no console errors