### PR TITLE
feat: sliding indicator animation polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ tabs:
 | `scrollable`  | `auto` \| boolean | `auto`       | Scroll the tab bar when tabs overflow. |
 | `remember`    | string            | `none`       | `none` \| `browser` \| `url`. |
 | `lazy`        | boolean           | `false`      | Create inactive tab cards on first visit instead of up front. |
+| `animated`    | boolean           | `true`       | Slide the active-tab indicator between tabs. Snaps instantly when `false` or under reduced-motion. |
 | `styles`      | object            | `{}`         | CSS-variable overrides (see Theming). |
 
 ### Tab options

--- a/dist/tabdeck-card.js
+++ b/dist/tabdeck-card.js
@@ -632,6 +632,7 @@ function normalizeConfig(raw) {
     scrollable: (raw == null ? void 0 : raw.scrollable) === void 0 ? "auto" : raw.scrollable,
     remember: pick(raw == null ? void 0 : raw.remember, REMEMBER, "none"),
     lazy: Boolean(raw == null ? void 0 : raw.lazy),
+    animated: (raw == null ? void 0 : raw.animated) === void 0 ? true : Boolean(raw.animated),
     styles: (raw == null ? void 0 : raw.styles) ?? {},
     tabs: tabs.map(normalizeTab)
   };
@@ -845,6 +846,48 @@ class TemplateRenderer extends EventTarget {
     this._entries.clear();
   }
 }
+const THICKNESS = 3;
+function computeIndicatorRect(tab, position, style) {
+  if (!tab || tab.offsetWidth <= 0) return null;
+  if (style === "pill" || style === "segmented") {
+    return {
+      left: tab.offsetLeft,
+      top: tab.offsetTop,
+      width: tab.offsetWidth,
+      height: tab.offsetHeight
+    };
+  }
+  switch (position) {
+    case "top":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop + tab.offsetHeight - THICKNESS,
+        width: tab.offsetWidth,
+        height: THICKNESS
+      };
+    case "bottom":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: tab.offsetWidth,
+        height: THICKNESS
+      };
+    case "left":
+      return {
+        left: tab.offsetLeft + tab.offsetWidth - THICKNESS,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight
+      };
+    case "right":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight
+      };
+  }
+}
 var __defProp$3 = Object.defineProperty;
 var __getOwnPropDesc$3 = Object.getOwnPropertyDescriptor;
 var __decorateClass$3 = (decorators, target, key, kind) => {
@@ -966,6 +1009,8 @@ let TabdeckTabbar = class extends i {
     this.position = "top";
     this.tabStyle = "underline";
     this.scrollable = "auto";
+    this.animated = true;
+    this._ready = false;
     this._onKeydown = (e2) => {
       const last = this.items.length - 1;
       const vertical = this.position === "left" || this.position === "right";
@@ -986,9 +1031,14 @@ let TabdeckTabbar = class extends i {
     super.connectedCallback();
     this.setAttribute("role", "tablist");
     this.addEventListener("keydown", this._onKeydown);
+    if (typeof ResizeObserver !== "undefined") {
+      this._resizeObserver = new ResizeObserver(() => this._position());
+    }
   }
   disconnectedCallback() {
+    var _a2;
     this.removeEventListener("keydown", this._onKeydown);
+    (_a2 = this._resizeObserver) == null ? void 0 : _a2.disconnect();
     super.disconnectedCallback();
   }
   _select(index) {
@@ -1000,9 +1050,51 @@ let TabdeckTabbar = class extends i {
       })
     );
   }
+  // Measure the selected tab and write the indicator's box inline. Guards for
+  // jsdom / pre-layout (offset* == 0) by hiding the indicator instead of moving
+  // it to (0,0).
+  _position() {
+    const root = this.renderRoot;
+    const indicator = root == null ? void 0 : root.querySelector(".indicator");
+    if (!indicator) return;
+    const tab = root == null ? void 0 : root.querySelector("tabdeck-tab[selected]");
+    const rect = tab ? computeIndicatorRect(
+      {
+        offsetLeft: tab.offsetLeft,
+        offsetTop: tab.offsetTop,
+        offsetWidth: tab.offsetWidth,
+        offsetHeight: tab.offsetHeight
+      },
+      this.position,
+      this.tabStyle
+    ) : null;
+    if (!rect) {
+      indicator.style.opacity = "0";
+      return;
+    }
+    indicator.style.left = `${rect.left}px`;
+    indicator.style.top = `${rect.top}px`;
+    indicator.style.width = `${rect.width}px`;
+    indicator.style.height = `${rect.height}px`;
+    indicator.style.opacity = "1";
+  }
+  firstUpdated() {
+    const bar = this.renderRoot.querySelector(".bar");
+    if (bar && this._resizeObserver) this._resizeObserver.observe(bar);
+  }
+  updated() {
+    this._position();
+    if (!this._ready) {
+      requestAnimationFrame(() => {
+        this._ready = true;
+      });
+    }
+  }
   render() {
+    const animateClass = this._ready && this.animated ? " animate" : "";
     return b`
       <div class="bar ${this.position} style-${this.tabStyle}" part="bar">
+        <div class="indicator${animateClass}" part="indicator"></div>
         ${this.items.map(
       (item, index) => b`
             <tabdeck-tab
@@ -1054,9 +1146,6 @@ TabdeckTabbar.styles = i$3`
     .bar.right {
       border-left: 1px solid var(--divider-color);
     }
-    .bar.style-underline tabdeck-tab[selected] {
-      box-shadow: inset 0 -3px 0 0 var(--tabdeck-accent, var(--primary-color));
-    }
     .bar.style-pill {
       gap: 6px;
       border: none;
@@ -1065,27 +1154,51 @@ TabdeckTabbar.styles = i$3`
     .bar.style-pill tabdeck-tab {
       border-radius: 999px;
     }
-    .bar.style-pill tabdeck-tab[selected] {
-      background: color-mix(
-        in srgb,
-        var(--tabdeck-accent, var(--primary-color)) 18%,
-        transparent
-      );
-    }
     .bar.style-segmented {
       gap: 0;
       border: 1px solid var(--divider-color);
       border-radius: 10px;
       padding: 4px;
     }
-    .bar.style-segmented tabdeck-tab[selected] {
+
+    /* The single moving indicator. Sits behind tab content. */
+    .indicator {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 0;
+      height: 0;
+      opacity: 0;
+      pointer-events: none;
+      z-index: 0;
+    }
+    .indicator.animate {
+      transition: left 200ms ease, top 200ms ease, width 200ms ease,
+        height 200ms ease;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .indicator.animate {
+        transition: none;
+      }
+    }
+    tabdeck-tab {
+      position: relative;
+      z-index: 1;
+    }
+    .bar.style-underline .indicator {
+      background: var(--tabdeck-accent, var(--primary-color));
+    }
+    .bar.style-pill .indicator {
+      background: color-mix(
+        in srgb,
+        var(--tabdeck-accent, var(--primary-color)) 18%,
+        transparent
+      );
+      border-radius: 999px;
+    }
+    .bar.style-segmented .indicator {
       background: var(--card-background-color);
       border-radius: 7px;
-    }
-    @media (prefers-reduced-motion: no-preference) {
-      tabdeck-tab {
-        transition: background 150ms ease, box-shadow 150ms ease;
-      }
     }
   `;
 __decorateClass$2([
@@ -1103,6 +1216,12 @@ __decorateClass$2([
 __decorateClass$2([
   n2()
 ], TabdeckTabbar.prototype, "scrollable", 2);
+__decorateClass$2([
+  n2({ type: Boolean })
+], TabdeckTabbar.prototype, "animated", 2);
+__decorateClass$2([
+  r$1()
+], TabdeckTabbar.prototype, "_ready", 2);
 TabdeckTabbar = __decorateClass$2([
   t$1("tabdeck-tabbar")
 ], TabdeckTabbar);
@@ -1310,6 +1429,7 @@ let TabdeckCard = class extends i {
         .position=${cfg.position}
         .tabStyle=${cfg.style}
         .scrollable=${cfg.scrollable}
+        .animated=${cfg.animated}
         @tabdeck-select=${this._onSelect}
       ></tabdeck-tabbar>
     `;
@@ -1619,6 +1739,15 @@ let TabdeckCardEditor = class extends i {
               @change=${(e2) => this._patch({ lazy: e2.target.checked })}
             />
             Lazy-mount inactive tabs
+          </label>
+          <label class="checkbox"
+            ><input
+              class="global-animated"
+              type="checkbox"
+              .checked=${cfg.animated}
+              @change=${(e2) => this._patch({ animated: e2.target.checked })}
+            />
+            Animate indicator
           </label>
         </div>
 

--- a/docs/superpowers/plans/2026-06-23-sliding-indicator.md
+++ b/docs/superpowers/plans/2026-06-23-sliding-indicator.md
@@ -1,0 +1,691 @@
+# Sliding Indicator Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the static per-tab active highlight with a single indicator element that slides and resizes to the active tab across all three styles and four positions.
+
+**Architecture:** One absolutely-positioned `<div class="indicator">` lives inside the scrolling `.bar` of `tabdeck-tabbar`. Its geometry is computed by a pure helper (`lib/indicator.ts`) from the selected tab's `offset*` box, written as inline `left/top/width/height`, and animated by a CSS transition gated behind an `.animate` class. A new `animated` config option (default `true`) and `prefers-reduced-motion` both control whether the slide animates or snaps.
+
+**Tech Stack:** TypeScript, Lit 3, Vite, Vitest (jsdom).
+
+## Global Constraints
+
+- **No Claude co-author attribution** anywhere in commits or files — no `Co-Authored-By`, no "Generated with Claude" footers.
+- Git identity: `tempus2016` / `john_mackinnon@live.co.uk`.
+- Complete files / complete code — no snippets-as-placeholders.
+- TDD: failing test first, then minimal implementation.
+- jsdom has **no** `ResizeObserver` and reports `offset*` as `0`; all DOM-geometry code must guard for both and never throw.
+- Default for `animated` is `true`. `prefers-reduced-motion: reduce` always snaps regardless of `animated`.
+- Indicator thickness for the `underline` style is a constant `3px` (matches today's underline).
+
+---
+
+### Task 1: Add `animated` config option
+
+**Files:**
+- Modify: `src/lib/config.ts` (interface `TabdeckCardConfig`, `normalizeConfig`)
+- Test: `src/lib/config.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `TabdeckCardConfig.animated: boolean`, defaulted in `normalizeConfig` to `true` unless explicitly `false`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/config.test.ts` inside the `describe("normalizeConfig", ...)` block:
+
+```ts
+it("defaults animated to true and respects explicit false", () => {
+  expect(normalizeConfig({ tabs: [{ card: {} }] }).animated).toBe(true);
+  expect(normalizeConfig({ animated: false, tabs: [{ card: {} }] }).animated).toBe(false);
+  expect(normalizeConfig({ animated: true, tabs: [{ card: {} }] }).animated).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/config.test.ts`
+Expected: FAIL — `animated` is `undefined`, not `true`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/lib/config.ts`, add the field to the interface (after `lazy: boolean;`):
+
+```ts
+  lazy: boolean;
+  animated: boolean;
+  styles: Record<string, string>;
+```
+
+And in `normalizeConfig`'s returned object (after the `lazy:` line):
+
+```ts
+    lazy: Boolean(raw?.lazy),
+    animated: raw?.animated === undefined ? true : Boolean(raw.animated),
+    styles: raw?.styles ?? {},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/config.test.ts`
+Expected: PASS (all tests in file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/config.ts src/lib/config.test.ts
+git commit -m "feat: add animated config option (default true)"
+```
+
+---
+
+### Task 2: Pure indicator-geometry helper
+
+**Files:**
+- Create: `src/lib/indicator.ts`
+- Test: `src/lib/indicator.test.ts`
+
+**Interfaces:**
+- Consumes: `TabPosition`, `TabStyle` from `./config`.
+- Produces:
+  - `interface TabGeometry { offsetLeft: number; offsetTop: number; offsetWidth: number; offsetHeight: number }`
+  - `interface IndicatorRect { left: number; top: number; width: number; height: number }`
+  - `function computeIndicatorRect(tab: TabGeometry, position: TabPosition, style: TabStyle): IndicatorRect | null` — returns `null` when `tab.offsetWidth <= 0` (unmeasurable / jsdom).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/indicator.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeIndicatorRect } from "./indicator";
+
+const tab = { offsetLeft: 10, offsetTop: 20, offsetWidth: 100, offsetHeight: 48 };
+
+describe("computeIndicatorRect", () => {
+  it("returns null when the tab is unmeasurable", () => {
+    const zero = { offsetLeft: 0, offsetTop: 0, offsetWidth: 0, offsetHeight: 0 };
+    expect(computeIndicatorRect(zero, "top", "underline")).toBeNull();
+  });
+
+  it("underline top: 3px bar at the bottom edge", () => {
+    expect(computeIndicatorRect(tab, "top", "underline")).toEqual({
+      left: 10, top: 65, width: 100, height: 3,
+    });
+  });
+
+  it("underline bottom: 3px bar at the top edge", () => {
+    expect(computeIndicatorRect(tab, "bottom", "underline")).toEqual({
+      left: 10, top: 20, width: 100, height: 3,
+    });
+  });
+
+  it("underline left: 3px bar at the right edge", () => {
+    expect(computeIndicatorRect(tab, "left", "underline")).toEqual({
+      left: 107, top: 20, width: 3, height: 48,
+    });
+  });
+
+  it("underline right: 3px bar at the left edge", () => {
+    expect(computeIndicatorRect(tab, "right", "underline")).toEqual({
+      left: 10, top: 20, width: 3, height: 48,
+    });
+  });
+
+  it("pill: full tab box", () => {
+    expect(computeIndicatorRect(tab, "top", "pill")).toEqual({
+      left: 10, top: 20, width: 100, height: 48,
+    });
+  });
+
+  it("segmented: full tab box regardless of position", () => {
+    expect(computeIndicatorRect(tab, "left", "segmented")).toEqual({
+      left: 10, top: 20, width: 100, height: 48,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/indicator.test.ts`
+Expected: FAIL — cannot resolve `./indicator`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/indicator.ts`:
+
+```ts
+import type { TabPosition, TabStyle } from "./config";
+
+export interface TabGeometry {
+  offsetLeft: number;
+  offsetTop: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+export interface IndicatorRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+// Matches the original static underline thickness.
+const THICKNESS = 3;
+
+// Geometry of the moving indicator over the selected tab. Pure so the math is
+// testable without a DOM (jsdom reports offset* as 0 → null, never throws).
+export function computeIndicatorRect(
+  tab: TabGeometry,
+  position: TabPosition,
+  style: TabStyle,
+): IndicatorRect | null {
+  if (!tab || tab.offsetWidth <= 0) return null;
+
+  if (style === "pill" || style === "segmented") {
+    return {
+      left: tab.offsetLeft,
+      top: tab.offsetTop,
+      width: tab.offsetWidth,
+      height: tab.offsetHeight,
+    };
+  }
+
+  // underline: a THICKNESS-thin bar on the bar's inner edge.
+  switch (position) {
+    case "top":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop + tab.offsetHeight - THICKNESS,
+        width: tab.offsetWidth,
+        height: THICKNESS,
+      };
+    case "bottom":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: tab.offsetWidth,
+        height: THICKNESS,
+      };
+    case "left":
+      return {
+        left: tab.offsetLeft + tab.offsetWidth - THICKNESS,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight,
+      };
+    case "right":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight,
+      };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/indicator.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/indicator.ts src/lib/indicator.test.ts
+git commit -m "feat: pure indicator-geometry helper"
+```
+
+---
+
+### Task 3: Render, position, and animate the indicator in the tab bar
+
+**Files:**
+- Modify: `src/components/tabdeck-tabbar.ts` (add `animated` property, indicator element, positioning, ResizeObserver, styling cleanup)
+- Modify: `src/tabdeck-card.ts` (pass `.animated=${cfg.animated}` to `<tabdeck-tabbar>`)
+- Test: `src/components/tabdeck-tabbar.test.ts`
+
+**Interfaces:**
+- Consumes: `computeIndicatorRect`, `TabGeometry` from `../lib/indicator`; `TabdeckCardConfig.animated` from Task 1.
+- Produces: `<tabdeck-tabbar>` renders exactly one `.indicator` child of `.bar`; `.indicator` gains the `animate` class iff `animated` is true and the first paint has completed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/components/tabdeck-tabbar.test.ts`. First add a helper that waits one animation frame, near the top after the imports:
+
+```ts
+const nextFrame = () =>
+  new Promise<void>((r) => requestAnimationFrame(() => r()));
+```
+
+Then add these tests inside the `describe("tabdeck-tabbar", ...)` block:
+
+```ts
+it("renders a single indicator element inside the bar", async () => {
+  const el = await mount();
+  const bar = el.shadowRoot.querySelector(".bar");
+  expect(bar.querySelectorAll(".indicator")).toHaveLength(1);
+});
+
+it("hides the indicator (opacity 0) when offsets are unmeasurable in jsdom", async () => {
+  const el = await mount();
+  expect(el.shadowRoot.querySelector(".indicator").style.opacity).toBe("0");
+});
+
+it("adds the animate class after first paint when animated (default)", async () => {
+  const el = await mount();
+  await nextFrame();
+  await el.updateComplete;
+  expect(
+    el.shadowRoot.querySelector(".indicator").classList.contains("animate"),
+  ).toBe(true);
+});
+
+it("never adds the animate class when animated is false", async () => {
+  const el = document.createElement("tabdeck-tabbar") as any;
+  el.items = [{ name: "A" }, { name: "B" }, { name: "C" }];
+  el.selected = 0;
+  el.animated = false;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await nextFrame();
+  await el.updateComplete;
+  expect(
+    el.shadowRoot.querySelector(".indicator").classList.contains("animate"),
+  ).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/components/tabdeck-tabbar.test.ts`
+Expected: FAIL — no `.indicator` element exists.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the entire contents of `src/components/tabdeck-tabbar.ts` with:
+
+```ts
+import { LitElement, html, css } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type { TabPosition, TabStyle } from "../lib/config";
+import { computeIndicatorRect } from "../lib/indicator";
+import "./tabdeck-tab";
+
+interface TabItem {
+  name?: string;
+  icon?: string;
+  accent?: string;
+  badge?: string;
+}
+
+@customElement("tabdeck-tabbar")
+export class TabdeckTabbar extends LitElement {
+  @property({ attribute: false }) items: TabItem[] = [];
+  @property({ type: Number }) selected = 0;
+  @property() position: TabPosition = "top";
+  @property() tabStyle: TabStyle = "underline";
+  @property() scrollable: "auto" | boolean = "auto";
+  @property({ type: Boolean }) animated = true;
+
+  // Becomes true one frame after the first paint, so the indicator's initial
+  // placement never slides in from the corner; only later moves animate.
+  @state() private _ready = false;
+
+  private _resizeObserver?: ResizeObserver;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute("role", "tablist");
+    this.addEventListener("keydown", this._onKeydown);
+    if (typeof ResizeObserver !== "undefined") {
+      this._resizeObserver = new ResizeObserver(() => this._position());
+    }
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("keydown", this._onKeydown);
+    this._resizeObserver?.disconnect();
+    super.disconnectedCallback();
+  }
+
+  private _select(index: number): void {
+    this.dispatchEvent(
+      new CustomEvent("tabdeck-select", {
+        detail: { index },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _onKeydown = (e: KeyboardEvent): void => {
+    const last = this.items.length - 1;
+    const vertical = this.position === "left" || this.position === "right";
+    const next = vertical ? "ArrowDown" : "ArrowRight";
+    const prev = vertical ? "ArrowUp" : "ArrowLeft";
+    let target: number | null = null;
+    if (e.key === next) target = this.selected >= last ? 0 : this.selected + 1;
+    else if (e.key === prev) target = this.selected <= 0 ? last : this.selected - 1;
+    else if (e.key === "Home") target = 0;
+    else if (e.key === "End") target = last;
+    if (target !== null) {
+      e.preventDefault();
+      this._select(target);
+    }
+  };
+
+  // Measure the selected tab and write the indicator's box inline. Guards for
+  // jsdom / pre-layout (offset* == 0) by hiding the indicator instead of moving
+  // it to (0,0).
+  private _position(): void {
+    const root = this.renderRoot as ParentNode | undefined;
+    const indicator = root?.querySelector(".indicator") as HTMLElement | null;
+    if (!indicator) return;
+    const tab = root?.querySelector("tabdeck-tab[selected]") as HTMLElement | null;
+    const rect = tab
+      ? computeIndicatorRect(
+          {
+            offsetLeft: tab.offsetLeft,
+            offsetTop: tab.offsetTop,
+            offsetWidth: tab.offsetWidth,
+            offsetHeight: tab.offsetHeight,
+          },
+          this.position,
+          this.tabStyle,
+        )
+      : null;
+    if (!rect) {
+      indicator.style.opacity = "0";
+      return;
+    }
+    indicator.style.left = `${rect.left}px`;
+    indicator.style.top = `${rect.top}px`;
+    indicator.style.width = `${rect.width}px`;
+    indicator.style.height = `${rect.height}px`;
+    indicator.style.opacity = "1";
+  }
+
+  protected firstUpdated(): void {
+    const bar = (this.renderRoot as ParentNode).querySelector(".bar");
+    if (bar && this._resizeObserver) this._resizeObserver.observe(bar);
+  }
+
+  protected updated(): void {
+    this._position();
+    if (!this._ready) {
+      requestAnimationFrame(() => {
+        this._ready = true;
+      });
+    }
+  }
+
+  render() {
+    const animateClass = this._ready && this.animated ? " animate" : "";
+    return html`
+      <div class="bar ${this.position} style-${this.tabStyle}" part="bar">
+        <div class="indicator${animateClass}" part="indicator"></div>
+        ${this.items.map(
+          (item, index) => html`
+            <tabdeck-tab
+              .label=${item.name}
+              .icon=${item.icon}
+              .badge=${item.badge}
+              .accent=${item.accent}
+              .selected=${index === this.selected}
+              aria-controls="tabdeck-panel"
+              @click=${() => this._select(index)}
+            ></tabdeck-tab>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .bar {
+      display: flex;
+      align-items: stretch;
+      border-bottom: 1px solid var(--divider-color);
+      position: relative;
+    }
+    .bar.top,
+    .bar.bottom {
+      flex-direction: row;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+    .bar::-webkit-scrollbar {
+      display: none;
+    }
+    .bar.bottom {
+      border-bottom: none;
+      border-top: 1px solid var(--divider-color);
+    }
+    .bar.left,
+    .bar.right {
+      flex-direction: column;
+      border-bottom: none;
+    }
+    .bar.left {
+      border-right: 1px solid var(--divider-color);
+    }
+    .bar.right {
+      border-left: 1px solid var(--divider-color);
+    }
+    .bar.style-pill {
+      gap: 6px;
+      border: none;
+      padding: 6px;
+    }
+    .bar.style-pill tabdeck-tab {
+      border-radius: 999px;
+    }
+    .bar.style-segmented {
+      gap: 0;
+      border: 1px solid var(--divider-color);
+      border-radius: 10px;
+      padding: 4px;
+    }
+
+    /* The single moving indicator. Sits behind tab content. */
+    .indicator {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 0;
+      height: 0;
+      opacity: 0;
+      pointer-events: none;
+      z-index: 0;
+    }
+    .indicator.animate {
+      transition: left 200ms ease, top 200ms ease, width 200ms ease,
+        height 200ms ease;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .indicator.animate {
+        transition: none;
+      }
+    }
+    tabdeck-tab {
+      position: relative;
+      z-index: 1;
+    }
+    .bar.style-underline .indicator {
+      background: var(--tabdeck-accent, var(--primary-color));
+    }
+    .bar.style-pill .indicator {
+      background: color-mix(
+        in srgb,
+        var(--tabdeck-accent, var(--primary-color)) 18%,
+        transparent
+      );
+      border-radius: 999px;
+    }
+    .bar.style-segmented .indicator {
+      background: var(--card-background-color);
+      border-radius: 7px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "tabdeck-tabbar": TabdeckTabbar;
+  }
+}
+```
+
+- [ ] **Step 4: Wire `animated` through the card**
+
+In `src/tabdeck-card.ts`, in `render()`, add the `.animated` binding to the `<tabdeck-tabbar>` element (alongside `.scrollable`):
+
+```ts
+        .scrollable=${cfg.scrollable}
+        .animated=${cfg.animated}
+        @tabdeck-select=${this._onSelect}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/components/tabdeck-tabbar.test.ts`
+Expected: PASS — including the original 4 tablist tests and the 4 new indicator tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/tabdeck-tabbar.ts src/tabdeck-card.ts src/components/tabdeck-tabbar.test.ts
+git commit -m "feat: sliding indicator element in the tab bar"
+```
+
+---
+
+### Task 4: Editor checkbox for `animated`
+
+**Files:**
+- Modify: `src/editor/tabdeck-card-editor.ts` (globals block)
+- Test: `src/editor/tabdeck-card-editor.test.ts`
+
+**Interfaces:**
+- Consumes: `_patch({ animated })`, `cfg.animated` from Task 1.
+- Produces: a `.global-animated` checkbox bound to `cfg.animated`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/editor/tabdeck-card-editor.test.ts` inside `describe("tabdeck-card-editor", ...)`:
+
+```ts
+it("toggles the global animated option", async () => {
+  const el = await mount({ tabs: [{ name: "A", card: {} }] });
+  const handler = vi.fn();
+  el.addEventListener("config-changed", handler);
+  const cb = el.shadowRoot.querySelector(".global-animated");
+  expect(cb.checked).toBe(true);
+  cb.checked = false;
+  cb.dispatchEvent(new Event("change"));
+  expect(handler.mock.calls.at(-1)[0].detail.config.animated).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/editor/tabdeck-card-editor.test.ts`
+Expected: FAIL — `.global-animated` is `null`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/editor/tabdeck-card-editor.ts`, in `_renderListView`, add a checkbox immediately after the existing lazy checkbox `</label>` (the one containing `.global-lazy`):
+
+```ts
+          <label class="checkbox"
+            ><input
+              class="global-animated"
+              type="checkbox"
+              .checked=${cfg.animated}
+              @change=${(e: any) => this._patch({ animated: e.target.checked })}
+            />
+            Animate indicator
+          </label>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/editor/tabdeck-card-editor.test.ts`
+Expected: PASS (all editor tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/editor/tabdeck-card-editor.ts src/editor/tabdeck-card-editor.test.ts
+git commit -m "feat: editor toggle for the animated indicator"
+```
+
+---
+
+### Task 5: Document `animated` and verify the full build
+
+**Files:**
+- Modify: `README.md` (card options table)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: documentation; no code.
+
+- [ ] **Step 1: Add the README row**
+
+In `README.md`, in the card options table, add a row immediately after the `lazy` row (line ~93):
+
+```markdown
+| `animated`    | boolean           | `true`       | Slide the active-tab indicator between tabs. Snaps instantly when `false` or under reduced-motion. |
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` updated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md dist
+git commit -m "docs: document the animated option; rebuild dist"
+```
+
+---
+
+## Notes for the implementer
+
+- **Why the indicator is a child of `.bar` (not `:host`):** `.bar` is the scroll
+  container and `position: relative`. The tab's `offsetLeft/offsetTop` are measured
+  relative to `.bar`'s padding box, which is exactly the containing block for the
+  absolutely-positioned `.indicator`. So the numbers line up and the indicator
+  scrolls in lockstep with the tabs — no scroll listener needed.
+- **First-paint suppression:** the `.animate` class is withheld until one frame
+  after first paint (`_ready`), so the initial placement is instant. After that,
+  selection/resize moves animate (when `animated` and not reduced-motion).
+- **Per-tab `accent`:** the single shared indicator reads the default
+  `--tabdeck-accent`; per-tab accent still colours each tab's own text/badge. This
+  is intentional and matches the approved spec (matching the moving indicator to
+  each tab's accent is out of scope).
+- **Removed in Task 3:** the three old `tabdeck-tab[selected]` highlight rules
+  (underline `box-shadow`, pill `background`, segmented `background`) and the dead
+  `@media (prefers-reduced-motion: no-preference) tabdeck-tab { transition: background, box-shadow }`
+  block — those properties no longer change on the tab. The selected-tab **text
+  colour** rule stays on `tabdeck-tab` (in `tabdeck-tab.ts`, untouched).

--- a/docs/superpowers/specs/2026-06-23-sliding-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-23-sliding-indicator-design.md
@@ -1,0 +1,144 @@
+# Sliding indicator animation polish — design
+
+**Date:** 2026-06-23
+**Feature:** #4 (final feature of the roadmap)
+
+## Problem
+
+Today there is no moving indicator. The active-tab highlight is static:
+
+- `underline` — `box-shadow: inset 0 -3px 0 0 accent` on the selected `tabdeck-tab`.
+- `pill` — static `background` (color-mix) on the selected tab.
+- `segmented` — static `background` + `border-radius` on the selected tab.
+
+Switching tabs swaps the highlight instantly. This feature introduces a real
+indicator element that **slides and resizes** to the active tab.
+
+## Approach
+
+A single absolutely-positioned indicator element inside the tab bar, positioned
+over the selected tab via that tab's `offset*` geometry, animated with a CSS
+transition. This is the standard Material/MWC tab-bar pattern. Rejected
+alternatives: FLIP animation on the per-tab highlight (more moving parts, awkward
+with resize and the three shapes), and the View Transitions API (patchy support
+in HA's webview, fiddly to scope through Shadow DOM).
+
+## Config
+
+Add `animated: boolean` to `TabdeckCardConfig`.
+
+- Normalized in `normalizeConfig`: `raw?.animated === undefined ? true : Boolean(raw.animated)`.
+- Default **true**.
+- When `false`, the indicator still tracks the active tab but snaps instantly
+  (no slide).
+- `prefers-reduced-motion: reduce` always forces snapping, regardless of the
+  `animated` value.
+
+Threaded `tabdeck-card.ts` render → `tabdeck-tabbar` via a `.animated` property.
+
+## Geometry helper — new `src/lib/indicator.ts` (pure, unit-tested)
+
+```
+computeIndicatorRect(
+  tab: { offsetLeft: number; offsetTop: number; offsetWidth: number; offsetHeight: number },
+  position: TabPosition,
+  style: TabStyle,
+): { left: number; top: number; width: number; height: number } | null
+```
+
+Rules:
+
+- **underline**, `top`/`bottom` → 3px-tall bar spanning the tab width at the bar's
+  inner edge (bottom edge for `top` position, top edge for `bottom` position).
+- **underline**, `left`/`right` → 3px-wide bar spanning the tab height at the inner
+  edge (right edge for `left` position, left edge for `right` position).
+- **pill** / **segmented** → the full tab box (`left/top` = tab's `offsetLeft/offsetTop`,
+  `width/height` = tab's `offsetWidth/offsetHeight`), for all positions. The
+  indicator element carries the rounded background.
+
+Keeping this pure means the math is unit-tested directly, independent of jsdom
+(where `offset*` reports 0).
+
+The 3px thickness reuses the current underline thickness; expressed via a
+`--tabdeck-indicator-size` custom property defaulting to 3px.
+
+## Tab bar component — `src/components/tabdeck-tabbar.ts`
+
+- Render one `<div class="indicator" part="indicator">` as the **first** child of
+  `.bar`.
+- New `@property({ type: Boolean }) animated = true`.
+- `@query(".indicator")` for the indicator; query the selected `tabdeck-tab` via
+  `[selected]`.
+- `_position(animate: boolean)`:
+  - Read the selected tab's `offsetLeft/offsetTop/offsetWidth/offsetHeight`.
+  - If there is no selected tab (or `offsetWidth` is 0, i.e. unmeasurable/jsdom),
+    set the indicator `opacity: 0` and return — never throw.
+  - Otherwise call `computeIndicatorRect` and write `left/top/width/height`
+    inline, set `opacity: 1`.
+- Reposition triggers:
+  - `updated()` — covers `selected`, `items`, `tabStyle`, `position` changes.
+  - `ResizeObserver` on `.bar` — covers container width and tab-width changes
+    (font load, badge text). Connected in `connectedCallback`, disconnected in
+    `disconnectedCallback`.
+  - **Scroll needs no handling**: the indicator is a child of the scrolling
+    `.bar`, so it scrolls in lockstep with the tabs.
+
+## Animation gating
+
+- The slide transition is on `left`/`top`/`width`/`height` (~200ms ease) —
+  matching the inline properties `_position` writes — applied via an `.animate`
+  class on the indicator, added only when `this.animated` is true.
+- `@media (prefers-reduced-motion: reduce)` zeroes the transition regardless, so
+  reduced-motion always snaps.
+- **First paint:** the indicator starts `opacity: 0` with no transition.
+  `firstUpdated` positions it, then a `requestAnimationFrame` sets `opacity: 1`
+  and (if `animated`) adds `.animate`. The first placement never slides in from
+  the corner; subsequent switches animate.
+
+## Styling cleanup
+
+Remove the three static `[selected]` highlight rules from `tabdeck-tabbar`:
+
+- `.bar.style-underline tabdeck-tab[selected]` box-shadow
+- `.bar.style-pill tabdeck-tab[selected]` background
+- `.bar.style-segmented tabdeck-tab[selected]` background
+
+Move that appearance onto the single `.indicator`, per-style:
+
+- `.style-underline .indicator` — accent-coloured bar.
+- `.style-pill .indicator` — color-mix pill background, `border-radius: 999px`.
+- `.style-segmented .indicator` — card background, `border-radius: 7px`.
+
+Selected-tab **text colour** stays on `tabdeck-tab` (unchanged). The indicator
+sits **behind** tab content for pill/segmented via `z-index` (indicator `z-index: 0`,
+tabs `position: relative; z-index: 1`).
+
+The accent uses the existing `--tabdeck-accent` resolution. Note: per-tab `accent`
+is set on the individual `tabdeck-tab` host, but the single shared indicator lives
+on the bar — so the indicator reads the **bar-level** accent. Per-tab accent
+colours continue to apply to the tab's own text/badge; the moving indicator uses
+the default accent. (Matching the indicator colour to each tab's per-tab accent is
+out of scope — see below.)
+
+## Editor + README
+
+- Editor (`tabdeck-card-editor.ts`): add an "Animate indicator" checkbox in the
+  globals block, mirroring the existing `cfg.lazy` checkbox (`_patch({ animated })`).
+- README: document `animated` (default `true`) in the options table.
+
+## Tests
+
+- `src/lib/indicator.test.ts` — `computeIndicatorRect` for all 3 styles × 4
+  positions, plus the no-selection / unmeasurable null case.
+- `src/components/tabdeck-tabbar.test.ts` — indicator element renders; `.animate`
+  class present iff `animated` is true; `_position` is guarded when `offset*` is 0
+  (no throw in jsdom).
+- `src/lib/config.test.ts` — `animated` defaults to `true`, respects explicit
+  `false`.
+- `src/editor/tabdeck-card-editor.test.ts` — the checkbox toggles `animated`.
+
+## Out of scope (YAGNI)
+
+- Per-tab indicator colours beyond making the indicator read the default accent.
+- Configurable transition duration / easing.
+- Indicator following hover.

--- a/src/components/tabdeck-tabbar.test.ts
+++ b/src/components/tabdeck-tabbar.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import "./tabdeck-tabbar";
 
+const nextFrame = () =>
+  new Promise<void>((r) => requestAnimationFrame(() => r()));
+
 async function mount() {
   const el = document.createElement("tabdeck-tabbar") as any;
   el.items = [{ name: "A" }, { name: "B" }, { name: "C" }];
@@ -50,5 +53,39 @@ describe("tabdeck-tabbar", () => {
     expect(events[events.length - 1]).toBe(2);
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
     expect(events[events.length - 1]).toBe(0);
+  });
+
+  it("renders a single indicator element inside the bar", async () => {
+    const el = await mount();
+    const bar = el.shadowRoot.querySelector(".bar");
+    expect(bar.querySelectorAll(".indicator")).toHaveLength(1);
+  });
+
+  it("hides the indicator (opacity 0) when offsets are unmeasurable in jsdom", async () => {
+    const el = await mount();
+    expect(el.shadowRoot.querySelector(".indicator").style.opacity).toBe("0");
+  });
+
+  it("adds the animate class after first paint when animated (default)", async () => {
+    const el = await mount();
+    await nextFrame();
+    await el.updateComplete;
+    expect(
+      el.shadowRoot.querySelector(".indicator").classList.contains("animate"),
+    ).toBe(true);
+  });
+
+  it("never adds the animate class when animated is false", async () => {
+    const el = document.createElement("tabdeck-tabbar") as any;
+    el.items = [{ name: "A" }, { name: "B" }, { name: "C" }];
+    el.selected = 0;
+    el.animated = false;
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await nextFrame();
+    await el.updateComplete;
+    expect(
+      el.shadowRoot.querySelector(".indicator").classList.contains("animate"),
+    ).toBe(false);
   });
 });

--- a/src/components/tabdeck-tabbar.ts
+++ b/src/components/tabdeck-tabbar.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { TabPosition, TabStyle } from "../lib/config";
+import { computeIndicatorRect } from "../lib/indicator";
 import "./tabdeck-tab";
 
 interface TabItem {
@@ -17,15 +18,26 @@ export class TabdeckTabbar extends LitElement {
   @property() position: TabPosition = "top";
   @property() tabStyle: TabStyle = "underline";
   @property() scrollable: "auto" | boolean = "auto";
+  @property({ type: Boolean }) animated = true;
+
+  // Becomes true one frame after the first paint, so the indicator's initial
+  // placement never slides in from the corner; only later moves animate.
+  @state() private _ready = false;
+
+  private _resizeObserver?: ResizeObserver;
 
   connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute("role", "tablist");
     this.addEventListener("keydown", this._onKeydown);
+    if (typeof ResizeObserver !== "undefined") {
+      this._resizeObserver = new ResizeObserver(() => this._position());
+    }
   }
 
   disconnectedCallback(): void {
     this.removeEventListener("keydown", this._onKeydown);
+    this._resizeObserver?.disconnect();
     super.disconnectedCallback();
   }
 
@@ -55,9 +67,56 @@ export class TabdeckTabbar extends LitElement {
     }
   };
 
+  // Measure the selected tab and write the indicator's box inline. Guards for
+  // jsdom / pre-layout (offset* == 0) by hiding the indicator instead of moving
+  // it to (0,0).
+  private _position(): void {
+    const root = this.renderRoot as ParentNode | undefined;
+    const indicator = root?.querySelector(".indicator") as HTMLElement | null;
+    if (!indicator) return;
+    const tab = root?.querySelector("tabdeck-tab[selected]") as HTMLElement | null;
+    const rect = tab
+      ? computeIndicatorRect(
+          {
+            offsetLeft: tab.offsetLeft,
+            offsetTop: tab.offsetTop,
+            offsetWidth: tab.offsetWidth,
+            offsetHeight: tab.offsetHeight,
+          },
+          this.position,
+          this.tabStyle,
+        )
+      : null;
+    if (!rect) {
+      indicator.style.opacity = "0";
+      return;
+    }
+    indicator.style.left = `${rect.left}px`;
+    indicator.style.top = `${rect.top}px`;
+    indicator.style.width = `${rect.width}px`;
+    indicator.style.height = `${rect.height}px`;
+    indicator.style.opacity = "1";
+  }
+
+  protected firstUpdated(): void {
+    const bar = (this.renderRoot as ParentNode).querySelector(".bar");
+    if (bar && this._resizeObserver) this._resizeObserver.observe(bar);
+  }
+
+  protected updated(): void {
+    this._position();
+    if (!this._ready) {
+      requestAnimationFrame(() => {
+        this._ready = true;
+      });
+    }
+  }
+
   render() {
+    const animateClass = this._ready && this.animated ? " animate" : "";
     return html`
       <div class="bar ${this.position} style-${this.tabStyle}" part="bar">
+        <div class="indicator${animateClass}" part="indicator"></div>
         ${this.items.map(
           (item, index) => html`
             <tabdeck-tab
@@ -109,9 +168,6 @@ export class TabdeckTabbar extends LitElement {
     .bar.right {
       border-left: 1px solid var(--divider-color);
     }
-    .bar.style-underline tabdeck-tab[selected] {
-      box-shadow: inset 0 -3px 0 0 var(--tabdeck-accent, var(--primary-color));
-    }
     .bar.style-pill {
       gap: 6px;
       border: none;
@@ -120,27 +176,51 @@ export class TabdeckTabbar extends LitElement {
     .bar.style-pill tabdeck-tab {
       border-radius: 999px;
     }
-    .bar.style-pill tabdeck-tab[selected] {
-      background: color-mix(
-        in srgb,
-        var(--tabdeck-accent, var(--primary-color)) 18%,
-        transparent
-      );
-    }
     .bar.style-segmented {
       gap: 0;
       border: 1px solid var(--divider-color);
       border-radius: 10px;
       padding: 4px;
     }
-    .bar.style-segmented tabdeck-tab[selected] {
+
+    /* The single moving indicator. Sits behind tab content. */
+    .indicator {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 0;
+      height: 0;
+      opacity: 0;
+      pointer-events: none;
+      z-index: 0;
+    }
+    .indicator.animate {
+      transition: left 200ms ease, top 200ms ease, width 200ms ease,
+        height 200ms ease;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .indicator.animate {
+        transition: none;
+      }
+    }
+    tabdeck-tab {
+      position: relative;
+      z-index: 1;
+    }
+    .bar.style-underline .indicator {
+      background: var(--tabdeck-accent, var(--primary-color));
+    }
+    .bar.style-pill .indicator {
+      background: color-mix(
+        in srgb,
+        var(--tabdeck-accent, var(--primary-color)) 18%,
+        transparent
+      );
+      border-radius: 999px;
+    }
+    .bar.style-segmented .indicator {
       background: var(--card-background-color);
       border-radius: 7px;
-    }
-    @media (prefers-reduced-motion: no-preference) {
-      tabdeck-tab {
-        transition: background 150ms ease, box-shadow 150ms ease;
-      }
     }
   `;
 }

--- a/src/editor/tabdeck-card-editor.test.ts
+++ b/src/editor/tabdeck-card-editor.test.ts
@@ -166,6 +166,17 @@ describe("tabdeck-card-editor", () => {
     expect(handler.mock.calls.at(-1)[0].detail.config.default_tab).toBe("B");
   });
 
+  it("toggles the global animated option", async () => {
+    const el = await mount({ tabs: [{ name: "A", card: {} }] });
+    const handler = vi.fn();
+    el.addEventListener("config-changed", handler);
+    const cb = el.shadowRoot.querySelector(".global-animated");
+    expect(cb.checked).toBe(true);
+    cb.checked = false;
+    cb.dispatchEvent(new Event("change"));
+    expect(handler.mock.calls.at(-1)[0].detail.config.animated).toBe(false);
+  });
+
   it("toggles the global lazy option", async () => {
     const el = await mount({ tabs: [{ name: "A", card: {} }] });
     const handler = vi.fn();

--- a/src/editor/tabdeck-card-editor.ts
+++ b/src/editor/tabdeck-card-editor.ts
@@ -257,6 +257,15 @@ export class TabdeckCardEditor extends LitElement {
             />
             Lazy-mount inactive tabs
           </label>
+          <label class="checkbox"
+            ><input
+              class="global-animated"
+              type="checkbox"
+              .checked=${cfg.animated}
+              @change=${(e: any) => this._patch({ animated: e.target.checked })}
+            />
+            Animate indicator
+          </label>
         </div>
 
         <div class="tabs">

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -13,6 +13,12 @@ describe("normalizeConfig", () => {
     expect(c.tabs).toHaveLength(1);
   });
 
+  it("defaults animated to true and respects explicit false", () => {
+    expect(normalizeConfig({ tabs: [{ card: {} }] }).animated).toBe(true);
+    expect(normalizeConfig({ animated: false, tabs: [{ card: {} }] }).animated).toBe(false);
+    expect(normalizeConfig({ animated: true, tabs: [{ card: {} }] }).animated).toBe(true);
+  });
+
   it("throws when there are no tabs", () => {
     expect(() => normalizeConfig({ tabs: [] })).toThrow(/at least one tab/i);
     expect(() => normalizeConfig({})).toThrow(/at least one tab/i);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,6 +21,7 @@ export interface TabdeckCardConfig {
   scrollable: "auto" | boolean;
   remember: RememberMode;
   lazy: boolean;
+  animated: boolean;
   styles: Record<string, string>;
   tabs: TabdeckTabConfig[];
 }
@@ -59,6 +60,7 @@ export function normalizeConfig(raw: any): TabdeckCardConfig {
     scrollable: raw?.scrollable === undefined ? "auto" : raw.scrollable,
     remember: pick(raw?.remember, REMEMBER, "none"),
     lazy: Boolean(raw?.lazy),
+    animated: raw?.animated === undefined ? true : Boolean(raw.animated),
     styles: raw?.styles ?? {},
     tabs: tabs.map(normalizeTab),
   };

--- a/src/lib/indicator.test.ts
+++ b/src/lib/indicator.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { computeIndicatorRect } from "./indicator";
+
+const tab = { offsetLeft: 10, offsetTop: 20, offsetWidth: 100, offsetHeight: 48 };
+
+describe("computeIndicatorRect", () => {
+  it("returns null when the tab is unmeasurable", () => {
+    const zero = { offsetLeft: 0, offsetTop: 0, offsetWidth: 0, offsetHeight: 0 };
+    expect(computeIndicatorRect(zero, "top", "underline")).toBeNull();
+  });
+
+  it("underline top: 3px bar at the bottom edge", () => {
+    expect(computeIndicatorRect(tab, "top", "underline")).toEqual({
+      left: 10, top: 65, width: 100, height: 3,
+    });
+  });
+
+  it("underline bottom: 3px bar at the top edge", () => {
+    expect(computeIndicatorRect(tab, "bottom", "underline")).toEqual({
+      left: 10, top: 20, width: 100, height: 3,
+    });
+  });
+
+  it("underline left: 3px bar at the right edge", () => {
+    expect(computeIndicatorRect(tab, "left", "underline")).toEqual({
+      left: 107, top: 20, width: 3, height: 48,
+    });
+  });
+
+  it("underline right: 3px bar at the left edge", () => {
+    expect(computeIndicatorRect(tab, "right", "underline")).toEqual({
+      left: 10, top: 20, width: 3, height: 48,
+    });
+  });
+
+  it("pill: full tab box", () => {
+    expect(computeIndicatorRect(tab, "top", "pill")).toEqual({
+      left: 10, top: 20, width: 100, height: 48,
+    });
+  });
+
+  it("segmented: full tab box regardless of position", () => {
+    expect(computeIndicatorRect(tab, "left", "segmented")).toEqual({
+      left: 10, top: 20, width: 100, height: 48,
+    });
+  });
+});

--- a/src/lib/indicator.ts
+++ b/src/lib/indicator.ts
@@ -1,0 +1,69 @@
+import type { TabPosition, TabStyle } from "./config";
+
+export interface TabGeometry {
+  offsetLeft: number;
+  offsetTop: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+export interface IndicatorRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+// Matches the original static underline thickness.
+const THICKNESS = 3;
+
+// Geometry of the moving indicator over the selected tab. Pure so the math is
+// testable without a DOM (jsdom reports offset* as 0 → null, never throws).
+export function computeIndicatorRect(
+  tab: TabGeometry,
+  position: TabPosition,
+  style: TabStyle,
+): IndicatorRect | null {
+  if (!tab || tab.offsetWidth <= 0) return null;
+
+  if (style === "pill" || style === "segmented") {
+    return {
+      left: tab.offsetLeft,
+      top: tab.offsetTop,
+      width: tab.offsetWidth,
+      height: tab.offsetHeight,
+    };
+  }
+
+  // underline: a THICKNESS-thin bar on the bar's inner edge.
+  switch (position) {
+    case "top":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop + tab.offsetHeight - THICKNESS,
+        width: tab.offsetWidth,
+        height: THICKNESS,
+      };
+    case "bottom":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: tab.offsetWidth,
+        height: THICKNESS,
+      };
+    case "left":
+      return {
+        left: tab.offsetLeft + tab.offsetWidth - THICKNESS,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight,
+      };
+    case "right":
+      return {
+        left: tab.offsetLeft,
+        top: tab.offsetTop,
+        width: THICKNESS,
+        height: tab.offsetHeight,
+      };
+  }
+}

--- a/src/tabdeck-card.ts
+++ b/src/tabdeck-card.ts
@@ -219,6 +219,7 @@ export class TabdeckCard extends LitElement {
         .position=${cfg.position}
         .tabStyle=${cfg.style}
         .scrollable=${cfg.scrollable}
+        .animated=${cfg.animated}
         @tabdeck-select=${this._onSelect}
       ></tabdeck-tabbar>
     `;


### PR DESCRIPTION
## Feature #4 — sliding indicator animation polish

Replaces the static per-tab active highlight with a single indicator element that **slides and resizes** to the active tab, across all three styles and four positions.

### What changed
- **New `animated` config option** (default `true`). When `false`, or under `prefers-reduced-motion`, the indicator snaps instantly instead of sliding.
- **Pure geometry helper** `lib/indicator.ts` (`computeIndicatorRect`) — computes the indicator box from the selected tab's `offset*`; unit-tested across 3 styles × 4 positions.
- **Tab bar** renders one absolutely-positioned `.indicator` inside the scrolling `.bar`, repositioned on selection/items/style/position change and via `ResizeObserver`. Scrolls in lockstep with the tabs (no scroll listener needed). First paint never slides in from the corner.
- **Styling cleanup** — removed the three old static `[selected]` highlight rules; appearance now lives on the single indicator (underline bar / pill / segmented), sitting behind tab content via `z-index`.
- **Editor** gains an "Animate indicator" checkbox.
- **README** documents the option.

### Tests
93 tests pass (`npm test`), build succeeds (`npm run build`). Note: `npm run typecheck` has pre-existing `Object is possibly undefined` errors in editor `*.test.ts` (present on `main`); production source typechecks clean.

Spec: `docs/superpowers/specs/2026-06-23-sliding-indicator-design.md` · Plan: `docs/superpowers/plans/2026-06-23-sliding-indicator.md`
