### PR TITLE
fix: guard .at(-1) in animated-toggle test for vitest 4

### DIFF
--- a/src/editor/tabdeck-card-editor.test.ts
+++ b/src/editor/tabdeck-card-editor.test.ts
@@ -174,7 +174,7 @@ describe("tabdeck-card-editor", () => {
     expect(cb.checked).toBe(true);
     cb.checked = false;
     cb.dispatchEvent(new Event("change"));
-    expect(handler.mock.calls.at(-1)[0].detail.config.animated).toBe(false);
+    expect(handler.mock.calls.at(-1)![0].detail.config.animated).toBe(false);
   });
 
   it("toggles the global lazy option", async () => {


### PR DESCRIPTION
Fixes typecheck breakage on main: PR #14 added the global-animated test with an unguarded `mock.calls.at(-1)[0]` while main still ran vitest 1. The vitest 4 bump (#9) now types `.at(-1)` as `T | undefined`, so `tsc` fails. Same non-null-assertion fix already applied to the other editor tests.

Verified locally: typecheck clean, 104 tests pass.