### PR TITLE
ci: bump Node to 24 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
`custom-card-helpers@2.0.0` declares `engines.node >=24`. Pinning the **Validate & Test** and **Release** workflows to Node 24 matches the dependency's intended runtime and clears the non-fatal `EBADENGINE` warning seen during `npm ci`.

Config-only change. Typecheck, tests (104 passing) and build already pass on this toolchain.