### PR TITLE
docs(wiki): consolidate option reference + sidebar

### DIFF
--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -9,12 +9,20 @@ All options live on the top-level card config (`type: custom:tabdeck-card`) exce
 | `tabs` | list | **required** | The tabs to show (at least one). See [Per-tab options](#per-tab-options). |
 | `default_tab` | number \| string | `0` | Tab shown first. A number is a 0-based index; a string matches a tab `name`. |
 | `position` | `top` \| `bottom` \| `left` \| `right` | `top` | Where the tab bar sits relative to the content. |
-| `style` | `underline` \| `pill` \| `segmented` | `underline` | Visual style of the tab bar. |
+| `style` | `underline` \| `pill` \| `segmented` \| `boxed` \| `text` | `underline` | Visual style of the tab bar. See [Extra bar styles](Feature-Bar-Styles). |
+| `tab_display` | `both` \| `icon` \| `label` | `both` | Show icons, labels, or both. See [Tab display mode](Feature-Tab-Display). |
+| `align` | `start` \| `center` \| `end` \| `justify` | `start` | How tabs are distributed along the bar. See [Tab alignment](Feature-Tab-Alignment). |
+| `badge_display` | `text` \| `dot` | `text` | Render badges as text or a dot. See [Badge display mode](Feature-Badge-Display). |
+| `transition` | `none` \| `fade` \| `slide` | `none` | Animate content on tab switch. See [Panel transitions](Feature-Panel-Transition). |
+| `indicator_size` | number (1–16) | `3` | Underline indicator thickness in px. See [Indicator thickness](Feature-Indicator-Size). |
+| `accent_indicator` | boolean | `true` | Colour the indicator by the selected tab's `accent`. See [Accent indicator](Feature-Accent-Indicator). |
 | `scrollable` | `auto` \| `true` \| `false` | `auto` | Whether the bar scrolls horizontally when tabs overflow. `auto` scrolls only when needed. |
+| `sticky` | boolean | `false` | Pin the bar while content scrolls. See [Sticky tab bar](Feature-Sticky-Bar). |
 | `remember` | `none` \| `browser` \| `url` | `none` | How the selected tab is remembered. See [Navigation & Persistence](Navigation-and-Persistence). |
 | `lazy` | boolean | `false` | When `true`, a tab's card is only built the first time it becomes visible. |
 | `animated` | boolean | `true` | Animate the selection indicator as it moves between tabs. |
 | `swipe` | boolean | `false` | Allow left/right swipe gestures to change tabs (mobile). |
+| `styles` | map | — | CSS variables/properties applied to the card. See [Theming](Feature-Theming). |
 
 > **Legacy:** `options.defaultTabIndex` is still accepted as a fallback for `default_tab`.
 
@@ -24,12 +32,16 @@ Each item in `tabs`:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `card` | card config | **required** | Any Lovelace card configuration. |
+| `card` | card config | **required**\* | Any Lovelace card configuration. |
+| `cards` | list of card configs | — | Multiple cards, auto-stacked. See [Multiple cards per tab](Feature-Multiple-Cards). \*Either `card` or `cards`. |
 | `name` | string | — | Tab label. Falls back to `Tab N` when omitted. |
+| `subtitle` | string | — | Secondary text under the label. See [Tab subtitles](Feature-Subtitle). |
 | `icon` | string (mdi) | — | Tab icon, e.g. `mdi:lightbulb`. |
-| `accent` | string (CSS colour) | — | Accent colour associated with the tab. |
+| `accent` | string (CSS colour) | — | Accent colour for the tab (indicator + selected state). |
+| `color` | string (CSS colour) | — | Fixed label/icon colour for the tab. See [Per-tab colour](Feature-Tab-Color). |
 | `badge` | string | — | An entity id (shows its state) or a Jinja template. See [Badges](Badges). |
-| `visibility` | list of conditions | — | Conditions that must **all** pass for the tab to show. See [Tab Visibility](Tab-Visibility). |
+| `disabled` | boolean | `false` | Show the tab greyed-out and non-selectable. See [Disabled tabs](Feature-Disabled-Tabs). |
+| `visibility` | list of conditions | — | Conditions for showing the tab (supports and/or/not). See [Tab Visibility](Tab-Visibility). |
 
 ## Full example
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,30 @@
+### Tabdeck Card
+
+- [Home](Home)
+- [Installation](Installation)
+- [Getting Started](Getting-Started)
+- [Configuration](Configuration)
+- [The Visual Editor](Editor)
+
+**Concepts**
+- [Tab Visibility](Tab-Visibility)
+- [Badges](Badges)
+- [Navigation & Persistence](Navigation-and-Persistence)
+- [Theming](Feature-Theming)
+
+**Features**
+- [All features](Features)
+- [Tab display mode](Feature-Tab-Display)
+- [Accent indicator](Feature-Accent-Indicator)
+- [Extra bar styles](Feature-Bar-Styles)
+- [Indicator thickness](Feature-Indicator-Size)
+- [Sticky tab bar](Feature-Sticky-Bar)
+- [Tab alignment](Feature-Tab-Alignment)
+- [Badge display mode](Feature-Badge-Display)
+- [Per-tab colour](Feature-Tab-Color)
+- [Tab subtitles](Feature-Subtitle)
+- [Disabled tabs](Feature-Disabled-Tabs)
+- [Multiple cards per tab](Feature-Multiple-Cards)
+- [Panel transitions](Feature-Panel-Transition)
+- [Duplicate tab](Feature-Duplicate-Tab)
+- [Expand/Collapse all](Feature-Editor-Expand-Collapse)


### PR DESCRIPTION
## Docs: wiki consolidation
- Configuration page now lists all current options (tab_display, align, badge_display, transition, indicator_size, accent_indicator, sticky, styles; per-tab subtitle, color, disabled, cards) with links to each feature page.
- Adds `_Sidebar.md` for wiki navigation.

Docs-only; no code changes.
