### PR TITLE
chore(scripts): sync-wiki uses cp instead of rsync

### DIFF
--- a/scripts/sync-wiki.sh
+++ b/scripts/sync-wiki.sh
@@ -19,7 +19,9 @@ echo "Cloning wiki repo..."
 git clone "$REMOTE" "$WORK"
 
 echo "Copying wiki/ -> wiki repo (images included)..."
-rsync -a --delete --exclude='.git' "$SRC_DIR"/ "$WORK"/
+# Remove tracked files (keep .git), then copy fresh — avoids an rsync dependency.
+find "$WORK" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+cp -a "$SRC_DIR"/. "$WORK"/
 
 cd "$WORK"
 git config user.name tempus2016


### PR DESCRIPTION
## chore: wiki sync without rsync
`scripts/sync-wiki.sh` now clears tracked files and `cp -a`s `wiki/` into the wiki clone (no rsync dependency). Verified: the full wiki (pages + images) is published to the GitHub wiki.
