### PR TITLE
docs: document + test nested decks

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -148,6 +148,13 @@ describe("normalizeConfig", () => {
     expect(c.tabs[0].card.type).toBe("vertical-stack");
   });
 
+  it("passes through a nested tabdeck-card as a tab's card", () => {
+    const inner = { type: "custom:tabdeck-card", tabs: [{ name: "X", card: { type: "markdown" } }] };
+    const c = normalizeConfig({ tabs: [{ name: "Outer", card: inner }] });
+    expect(c.tabs[0].card.type).toBe("custom:tabdeck-card");
+    expect(c.tabs[0].card.tabs).toHaveLength(1);
+  });
+
   it("keeps a single `card` when no `cards` array is present", () => {
     const c = normalizeConfig({ tabs: [{ name: "A", card: { type: "light" } }] });
     expect(c.tabs[0].card.type).toBe("light");

--- a/wiki/Feature-Nested.md
+++ b/wiki/Feature-Nested.md
@@ -1,0 +1,33 @@
+# Nested decks
+
+A tab's card can be **another Tabdeck card**, giving you sub-tabs (a tab group inside a tab).
+
+```yaml
+type: custom:tabdeck-card
+tabs:
+  - name: Downstairs
+    icon: mdi:home-floor-0
+    card:
+      type: custom:tabdeck-card      # a nested deck
+      style: pill
+      tabs:
+        - name: Living
+          card: { type: thermostat, entity: climate.living }
+        - name: Kitchen
+          card: { type: light, entity: light.kitchen }
+  - name: Upstairs
+    icon: mdi:home-floor-1
+    card:
+      type: custom:tabdeck-card
+      tabs:
+        - name: Bed 1
+          card: { ... }
+        - name: Bed 2
+          card: { ... }
+```
+
+## Notes
+
+- Each deck keeps its own state, styling and persistence. Give the inner deck a distinct [`storage_key`](Navigation-and-Persistence) (or `remember: url` with unique names) if you persist both.
+- The inner deck's keep-alive means its sub-tab cards (maps, cameras) render correctly too.
+- There's no hard nesting limit, but two levels is usually plenty.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -20,6 +20,7 @@ Every Tabdeck feature is **opt-in / configurable** — turn things on or off to 
 - **[Hide inactive badges](Feature-Hide-Inactive-Badge)** — hide 0/off badges (`hide_inactive_badge`).
 - **[Per-tab badge colour](Feature-Badge-Color)** — colour a tab's badge (`badge_color`).
 - **[Multiple cards per tab](Feature-Multiple-Cards)** — stack several cards in one tab (`cards`).
+- **[Nested decks](Feature-Nested)** — a tab's card can be another Tabdeck card (sub-tabs).
 - **[Disabled tabs](Feature-Disabled-Tabs)** — show a tab greyed-out and non-selectable (`disabled`).
 - **[Tab subtitles](Feature-Subtitle)** — secondary text under a tab label (`subtitle`).
 - **[Content header](Feature-Header)** — show the active tab's title above the content (`header`); icon-rail recipe.


### PR DESCRIPTION
## Nested decks
A tab's card may be another `custom:tabdeck-card`, giving sub-tabs. No code change needed (the card builds any nested card type with keep-alive).

## Testing
- Unit: nested tabdeck config passes through normalize. 201 tests pass.
- Verified on ha-dev via browserless — outer + inner tabbars both render (Outer-A/B, Inner-1/2), zero console errors.

## Docs
- New wiki page **Feature-Nested**; Features index updated.
