### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes are documented here. Release notes are also generated
 automatically on GitHub (see `.github/release.yml`).
 
-## Unreleased
+## v1.0.0 — 2026-06-24
 
-A large feature expansion — every item is an opt-in option, unit-tested,
+First stable release. A large feature expansion — every item is an opt-in option, unit-tested,
 verified on a real Home Assistant instance, and documented on the
 [Wiki](https://github.com/tempus2016/tabdeck-card/wiki).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabdeck-card",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabdeck-card",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "custom-card-helpers": "^2.0.0",
         "lit": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabdeck-card",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A modern tabbed card for Home Assistant Lovelace dashboards.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v1.0.0
First stable release. Bumps package version 0.1.0 → 1.0.0 and dates the CHANGELOG `v1.0.0` section.

After merge, pushing the `v1.0.0` tag triggers `release.yml` (build + GitHub release with `tabdeck-card.js` asset + generated notes) and `release-announcement.yml`.
