### PR TITLE
docs(release): thorough changelog-driven release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,19 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - name: Extract release notes from CHANGELOG
+        run: |
+          awk -v tag="$GITHUB_REF_NAME" '
+            $0 ~ "^## "tag { flag=1; next }
+            /^## / && flag { exit }
+            flag { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          # Fall back to a CHANGELOG link if the tag has no matching section.
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "See the [CHANGELOG](https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md)." > RELEASE_NOTES.md
+          fi
+          echo "----- release notes -----"; cat RELEASE_NOTES.md
       - uses: softprops/action-gh-release@v3
         with:
           files: dist/tabdeck-card.js
-          generate_release_notes: true
+          body_path: RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,46 @@
 # Changelog
 
-All notable changes are documented here. Release notes are also generated
-automatically on GitHub (see `.github/release.yml`).
+All notable changes are documented here. Each GitHub release uses the matching
+section below as its release notes (see `.github/workflows/release.yml`).
 
 ## v1.0.0 — 2026-06-24
 
-First stable release. A large feature expansion — every item is an opt-in option, unit-tested,
-verified on a real Home Assistant instance, and documented on the
-[Wiki](https://github.com/tempus2016/tabdeck-card/wiki).
+First stable release of **Tabdeck Card** — a dependency-free, themeable tabbed Lovelace card with a full visual editor and keep-alive content (maps, cameras and graphs render correctly without the "navigate away and back" workaround). Every capability below is an opt-in option, unit-tested, verified on a real Home Assistant instance, and documented on the [Wiki](https://github.com/tempus2016/tabdeck-card/wiki).
 
-### Tab bar appearance
-- `tab_display` (icon / label / both)
-- `accent_indicator` — indicator adopts the selected tab's accent
-- New styles: `boxed`, `text`
-- `indicator_size` — underline thickness
-- `align` — start / center / end / justify
-- `sticky` tab bar; `elevation` + `bar_background`
-- `scroll_buttons` for overflowing bars
+### Added — Tab bar & styling
+- **Five bar styles** — `style: underline | pill | segmented | boxed | text | rail`. `boxed` renders each tab as a bordered chip, `text` drops the indicator entirely, and `rail` is a compact icon rail for `position: left/right`.
+- **Display modes** — `tab_display: both | icon | label` to show icons, labels, or both; icon-only falls back to the label for tabs without an icon so a tab is never empty.
+- **Indicator controls** — `accent_indicator` colours the moving indicator by the selected tab's `accent`; `indicator_size` sets the underline thickness; `indicator_radius` overrides the pill/segmented/boxed/rail corner radius.
+- **Alignment** — `align: start | center | end | justify` distributes the tabs along the bar.
+- **Bar surface** — `sticky` pins the bar while content scrolls; `elevation` adds a shadow; `bar_background` sets a custom bar colour.
+- **Overflow handling** — `scroll_buttons` adds ‹ › arrows and `overflow_menu` adds a ⋯ jump-to-tab menu, both appearing only when the bar overflows.
 
-### Per-tab
-- `subtitle`, `color`, `badge_color`, `badge_display` (text / dot), `hide_inactive_badge`
-- `disabled` (greyed, non-selectable)
-- `hold_action` (long-press → HA action)
-- multiple `cards` with optional `columns` grid
+### Added — Per-tab options
+- **Labelling** — per-tab `name`, `subtitle` (secondary line), `icon`, `accent`, and `color` (fixed label/icon colour independent of selection).
+- **Badges** — `badge` from an entity state or Jinja template, with `badge_display: text | dot`, per-tab `badge_color`, and a global `hide_inactive_badge` to drop 0/off badges.
+- **Actions** — `hold_action` (long-press a tab) and `badge_action` (click a badge) fire any Home Assistant action without disrupting tab selection.
+- **Disabled & sizing** — `disabled` greys out a tab and skips it in keyboard nav; `card_size` provides a `getCardSize()` hint for stable masonry sizing.
+- **Multiple cards** — `cards: [...]` stacks several cards in one tab, with optional `columns: N` for a grid; tabs can also nest another Tabdeck card for sub-tabs.
 
-### Dynamic behaviour
-- Visibility `and` / `or` / `not` groups, plus `time` and `user` conditions
-- `auto_select` — switch tab when an entity becomes active
-- `default_if` — conditional default tab
-- `transition` — fade / slide panel animations
+### Added — Dynamic behaviour
+- **Rich visibility** — `visibility` conditions support `state`, `numeric_state`, `screen`, `time` (with overnight ranges + weekday), `user`, `template`, and nestable `and` / `or` / `not` groups.
+- **Auto-select** — `auto_select` switches to a tab (edge-triggered) when an entity becomes active or enters a given state.
+- **Conditional default** — `default_if` picks the starting tab based on current state.
+- **Transitions** — `transition: fade | slide` animates the panel on tab switch (respects reduced-motion).
 
-### Persistence & performance
-- `remember: entity` (cross-device) + `storage_key`
-- `unmount_hidden`, `swipe_wrap`, debounced resize
+### Added — Navigation & persistence
+- **Selection memory** — `remember: none | browser | url | entity`; `entity` mode syncs the active tab across devices via an `input_number`/`input_text`, and `storage_key` isolates browser-mode persistence.
+- **Gestures & keyboard** — touch `swipe` and desktop `swipe_mouse` (with optional `swipe_wrap`), plus full keyboard navigation (arrows / Home / End, skipping disabled tabs).
+- **Performance** — `lazy` mounting and `unmount_hidden` for memory-heavy dashboards; tab-bar resize handling is debounced.
 
-### Editor
-- Collapsible tab blocks, expand/collapse-all, auto-expand new tab
-- Drag-to-reorder, duplicate tab, duplicate-name warnings
-- Custom-card presets in the type chooser
+### Added — Visual editor
+- Collapsible per-tab blocks (with expand-all / collapse-all and auto-expand on add), **drag-to-reorder**, duplicate-tab, and duplicate-name warnings.
+- A live tab-bar **preview**, a card-type chooser with common built-in **and** popular custom (HACS) card presets, and Home Assistant's native card editor on drill-in.
 
-### Theming & docs
-- `styles` passthrough (CSS variables), `header` strip
-- Full GitHub wiki, README refresh, `examples/demo.yaml`
+### Added — Theming, accessibility & docs
+- `styles` passthrough for CSS variables (no card-mod needed) and an optional content `header` showing the active tab's title.
+- Proper `tablist` semantics: `aria-selected`, roving `tabindex`, focus rings, badge labels, and a configurable `aria_label`.
+- A complete GitHub **Wiki**, refreshed README with status badges, and `examples/demo.yaml`.
+
+### Upgrading
+Install or update via **HACS** (or copy `tabdeck-card.js` to `config/www/` and add it as a dashboard resource), then refresh your browser. Existing `kinghat/tabbed-card` configs keep working — `options.defaultTabIndex` maps to `default_tab` and per-tab `attributes.label`/`attributes.icon` map to `name`/`icon`.


### PR DESCRIPTION
## Release notes format
- **CHANGELOG.md** v1.0.0 section rewritten in TaskMate's style: grouped sections, bold lead-ins, thorough descriptions, and an **Upgrading** section.
- **release.yml** extracts the matching `## <tag>` section from CHANGELOG.md into `RELEASE_NOTES.md` and passes it as `body_path` (drops `generate_release_notes`), so future releases use the authored notes. Falls back to a CHANGELOG link if a tag has no section.

Docs/CI-config only.
