### PR TITLE
chore: add a sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Puts a Sponsor button on the repository. Nothing here asks for anything: this is
+# free, stays free, and works the same either way.
+buy_me_a_coffee: johnmackinnon


### PR DESCRIPTION
`.github/FUNDING.yml` pointing at [buymeacoffee.com/johnmackinnon](https://buymeacoffee.com/johnmackinnon), which GitHub turns into a **Sponsor** button on the repository page.

Nothing here changes — this is free, stays free, and behaves the same whether anyone ever presses it. Deliberately not mentioned in the README: the button is enough.